### PR TITLE
[Feature] JWT, Redis 기본 설정

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -34,6 +34,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-    
 
+      # application-jwt.yml 파일 생성
+      - name: make application-jwt.yml
+        run: |
+          cd ./src/main/resources
+          touch ./application-jwt.yml
+          echo "${{ secrets.APPLICATION_JWT_YML }}" > ./application-jwt.yml
+        shell: bash
+
       # application-dev.yml 파일 생성
       - name: make application-dev.yml
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,10 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+	// Spring Data Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// jwt
+	implementation 'com.auth0:java-jwt:4.2.1'
 	// Validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	// Spring Web

--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/pawwithu/connectdog/ConnectdogApplication.java
+++ b/src/main/java/com/pawwithu/connectdog/ConnectdogApplication.java
@@ -2,9 +2,11 @@ package com.pawwithu.connectdog;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
+@EnableCaching
 @SpringBootApplication
 public class ConnectdogApplication {
 

--- a/src/main/java/com/pawwithu/connectdog/config/RedisConfig.java
+++ b/src/main/java/com/pawwithu/connectdog/config/RedisConfig.java
@@ -1,0 +1,73 @@
+package com.pawwithu.connectdog.config;
+
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CachingConfigurerSupport;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig extends CachingConfigurerSupport {
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean(name = "redisTemplate")
+    public RedisTemplate<Long, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<Long, String> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+
+    @Bean(name = "redisBlackListTemplate")
+    public RedisTemplate<String, String> redisBlackListTemplate(RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+
+    // Redis Cache 적용을 위한 RedisCacheManager 설정
+    @Bean
+    public RedisCacheManager redisCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext
+                        .SerializationPair.fromSerializer(new StringRedisSerializer())) // StringRedisSerializer: binary 데이터로 저장되기 때문에 이를 String 으로 변환
+                .serializeValuesWith(RedisSerializationContext
+                        .SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofDays(14).plusHours(2)); // TTL 2주 + 2시간으로 설정
+
+        return RedisCacheManager
+                .RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
+
+}

--- a/src/main/java/com/pawwithu/connectdog/config/RedisConfig.java
+++ b/src/main/java/com/pawwithu/connectdog/config/RedisConfig.java
@@ -21,7 +21,7 @@ import java.time.Duration;
 @Configuration
 @EnableRedisRepositories
 public class RedisConfig extends CachingConfigurerSupport {
-    @Value("${spring.data.redis.port:6379}") // 기본 값 6379 설정
+    @Value("${spring.data.redis.port}")
     private int port;
 
     @Value("${spring.data.redis.host}")

--- a/src/main/java/com/pawwithu/connectdog/config/RedisConfig.java
+++ b/src/main/java/com/pawwithu/connectdog/config/RedisConfig.java
@@ -1,6 +1,8 @@
 package com.pawwithu.connectdog.config;
 
 
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.CachingConfigurerSupport;
 import org.springframework.context.annotation.Bean;
@@ -11,12 +13,11 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.RedisSerializationContext;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.redis.serializer.*;
 
 import java.time.Duration;
 
+@Slf4j
 @Configuration
 @EnableRedisRepositories
 public class RedisConfig extends CachingConfigurerSupport {
@@ -25,6 +26,13 @@ public class RedisConfig extends CachingConfigurerSupport {
 
     @Value("${spring.data.redis.host}")
     private String host;
+
+    @PostConstruct // 해당 메서드는 객체의 모든 의존성이 주입된 직후에 자동으로 호출
+    public void printValues() {
+        log.info("Redis Host: " + host);
+        log.info("Redis Port: " + port);
+    }
+
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
@@ -36,7 +44,7 @@ public class RedisConfig extends CachingConfigurerSupport {
         RedisTemplate<Long, String> redisTemplate = new RedisTemplate<>();
 
         redisTemplate.setConnectionFactory(redisConnectionFactory);
-        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setKeySerializer(new GenericToStringSerializer<Long>(Long.class)); // Long 타입에 대한 직렬화 도구로 GenericToStringSerializer 사용
         redisTemplate.setValueSerializer(new StringRedisSerializer());
 
         return redisTemplate;

--- a/src/main/java/com/pawwithu/connectdog/config/RedisConfig.java
+++ b/src/main/java/com/pawwithu/connectdog/config/RedisConfig.java
@@ -21,7 +21,7 @@ import java.time.Duration;
 @Configuration
 @EnableRedisRepositories
 public class RedisConfig extends CachingConfigurerSupport {
-    @Value("${spring.data.redis.port}")
+    @Value("${spring.data.redis.port:6379}") // 기본 값 6379 설정
     private int port;
 
     @Value("${spring.data.redis.host}")

--- a/src/main/java/com/pawwithu/connectdog/config/SecurityConfig.java
+++ b/src/main/java/com/pawwithu/connectdog/config/SecurityConfig.java
@@ -1,0 +1,59 @@
+package com.pawwithu.connectdog.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.security.web.servlet.util.matcher.MvcRequestMatcher;
+import org.springframework.web.servlet.handler.HandlerMappingIntrospector;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Slf4j
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http, HandlerMappingIntrospector introspector) throws Exception {
+        MvcRequestMatcher.Builder mvcMatcherBuilder = new MvcRequestMatcher.Builder(introspector);
+        http
+                .formLogin(formLogin -> formLogin.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .csrf(csrf -> csrf.disable())
+                .cors(withDefaults())
+                .headers(headers -> headers.frameOptions(frameOptions -> frameOptions.disable()))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(request ->
+                        request.requestMatchers(mvcMatcherBuilder.pattern("/login")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/api/sign-up")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/h2-console/**")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/css/**")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/js/**")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/images/**")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/error")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/favicon.ico")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/swagger-ui/**")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/swagger-resources/**")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/v3/api-docs/**")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/api/sign-up/email")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/api/members/userName/isDuplicated")).permitAll()
+                                .anyRequest().authenticated());
+
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
@@ -33,7 +33,7 @@ public class SignUpController {
     @PostMapping
     public ResponseEntity<Void> signUp(@RequestBody SignUpRequest signUpRequest) {
         authService.signUp(signUpRequest);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
@@ -1,0 +1,39 @@
+package com.pawwithu.connectdog.domain.auth.controller;
+
+import com.pawwithu.connectdog.domain.auth.dto.request.SignUpRequest;
+import com.pawwithu.connectdog.domain.auth.service.AuthService;
+import com.pawwithu.connectdog.error.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Sign-Up", description = "Sign-Up API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/sign-up")
+public class SignUpController {
+
+    private final AuthService authService;
+
+    @Operation(summary = "자체 회원가입", description = "이메일을 사용해 회원가입을 합니다.",
+            responses = {@ApiResponse(responseCode = "204", description = "자체 회원가입 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "1. 이미 존재하는 이메일입니다. \t\n 2. 이미 존재하는 사용자 닉네임입니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @PostMapping
+    public ResponseEntity<Void> signUp(@RequestBody SignUpRequest signUpRequest) {
+        authService.signUp(signUpRequest);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/SignUpRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/SignUpRequest.java
@@ -1,0 +1,25 @@
+package com.pawwithu.connectdog.domain.auth.dto.request;
+
+import com.pawwithu.connectdog.domain.member.entity.Member;
+import com.pawwithu.connectdog.domain.member.entity.Role;
+
+public record SignUpRequest(
+        String email, String password, String nickname,
+        String name, String phone,
+        String url,
+        Boolean isOptionAgr,
+        Role role
+) {
+    public Member toEntity() {
+        return Member.builder()
+                .email(email)
+                .password(password)
+                .nickname(nickname)
+                .name(name)
+                .phone(phone)
+                .url(url)
+                .isOptionAgr(isOptionAgr)
+                .role(role)
+                .build();
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
@@ -1,0 +1,39 @@
+package com.pawwithu.connectdog.domain.auth.service;
+
+import com.pawwithu.connectdog.domain.auth.dto.request.SignUpRequest;
+import com.pawwithu.connectdog.domain.member.entity.Member;
+import com.pawwithu.connectdog.domain.member.repository.MemberRepository;
+import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.pawwithu.connectdog.error.ErrorCode.ALREADY_EXIST_EMAIL;
+import static com.pawwithu.connectdog.error.ErrorCode.ALREADY_EXIST_NICKNAME;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    public void signUp(SignUpRequest signUpRequest) {
+
+        if (memberRepository.existsByEmail(signUpRequest.email())) {
+            throw new BadRequestException(ALREADY_EXIST_EMAIL);
+        }
+        if (memberRepository.existsByNickname(signUpRequest.nickname())) {
+            throw new BadRequestException(ALREADY_EXIST_NICKNAME);
+        }
+
+        Member member = signUpRequest.toEntity();
+        member.passwordEncode(passwordEncoder);
+        memberRepository.save(member);
+    }
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/member/entity/Member.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/member/entity/Member.java
@@ -1,0 +1,53 @@
+package com.pawwithu.connectdog.domain.member.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email; // 이메일
+    private String password; // 비밀번호
+    private String nickname; // 닉네임
+    private String name; // 이름
+    private String phone; // 이동봉사자 휴대폰 번호
+    private String url; // 이동봉사 단체 링크
+    private Boolean isOptionAgr; // 선택 이용약관 체크 여부
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    @Enumerated(EnumType.STRING)
+    private SocialType socialType; // KAKAO, NAVER
+
+    private String socialId; // 로그인한 소셜 타입 식별자 값 (일반 로그인의 경우 null)
+
+    @Builder
+    public Member(String email, String password, String nickname, String name, String phone, String url, Boolean isOptionAgr, Role role, SocialType socialType, String socialId) {
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+        this.name = name;
+        this.phone = phone;
+        this.url = url;
+        this.isOptionAgr = isOptionAgr;
+        this.role = role;
+        this.socialType = socialType;
+        this.socialId = socialId;
+    }
+
+    public void passwordEncode(PasswordEncoder passwordEncoder) {
+        this.password = passwordEncoder.encode(this.password);
+    }
+
+
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/member/entity/Role.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/member/entity/Role.java
@@ -1,0 +1,15 @@
+package com.pawwithu.connectdog.domain.member.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    // 첫 로그인, 테스트 여부 구분
+    GUEST("ROLE_GUEST"), USER("ROLE_USER"), ADMIN("ROLE_ADMIN");
+
+    private final String key;
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/member/entity/SocialType.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/member/entity/SocialType.java
@@ -1,0 +1,5 @@
+package com.pawwithu.connectdog.domain.member.entity;
+
+public enum SocialType {
+    KAKAO, NAVER
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/member/repository/MemberRepository.java
@@ -1,0 +1,20 @@
+package com.pawwithu.connectdog.domain.member.repository;
+
+import com.pawwithu.connectdog.domain.member.entity.Member;
+import com.pawwithu.connectdog.domain.member.entity.SocialType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    Optional<Member> findByEmail(String email);
+    Optional<Member> findByNickname(String nickname);
+
+    // 소셜 타입과 소셜의 식별값으로 회원 찾는 메소드 -> 추가 정보를 입력받아 회원가입 진행 시 이용
+    Optional<Member> findBySocialTypeAndSocialId(SocialType socialType, String socialId);
+
+    Boolean existsByEmail(String email);
+    Boolean existsByNickname(String nickname);
+
+}

--- a/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
+++ b/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
@@ -3,14 +3,13 @@ package com.pawwithu.connectdog.error;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import static org.springframework.http.HttpStatus.BAD_REQUEST;
-
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
 
     ALREADY_EXIST_EMAIL("A1", "이미 존재하는 이메일입니다."),
     ALREADY_EXIST_NICKNAME("A2", "이미 존재하는 사용자 닉네임입니다."),
+    ALREADY_LOGOUT_MEMBER("A3", "이미 로그아웃한 회원입니다"),
 
     TOKEN_NOT_EXIST("T1", "토큰이 존재하지 않습니다."),
     TOKEN_IS_EXPIRED("T2", "만료된 토큰입니다."),

--- a/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
+++ b/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
@@ -3,13 +3,19 @@ package com.pawwithu.connectdog.error;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
 
+    ALREADY_EXIST_EMAIL("A1", "이미 존재하는 이메일입니다."),
+    ALREADY_EXIST_NICKNAME("A2", "이미 존재하는 사용자 닉네임입니다."),
+
     TOKEN_NOT_EXIST("T1", "토큰이 존재하지 않습니다."),
     TOKEN_IS_EXPIRED("T2", "만료된 토큰입니다."),
     INVALID_TOKEN("T3", "잘못된 토큰입니다.");
+
 
     private final String code;
     private final String message;

--- a/src/main/java/com/pawwithu/connectdog/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/pawwithu/connectdog/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -1,33 +1,18 @@
 package com.pawwithu.connectdog.jwt.filter;
 
-import com.pawwithu.connectdog.domain.member.entity.Member;
-import com.pawwithu.connectdog.domain.member.repository.MemberRepository;
-import com.pawwithu.connectdog.error.exception.custom.TokenException;
 import com.pawwithu.connectdog.jwt.service.JwtService;
-import com.pawwithu.connectdog.jwt.util.PasswordUtil;
-import com.pawwithu.connectdog.util.RedisUtil;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
-import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
-
-import static com.pawwithu.connectdog.error.ErrorCode.ALREADY_LOGOUT_MEMBER;
-import static com.pawwithu.connectdog.error.ErrorCode.INVALID_TOKEN;
 
 /**
  * Jwt 인증 필터
@@ -38,12 +23,7 @@ import static com.pawwithu.connectdog.error.ErrorCode.INVALID_TOKEN;
 public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
     private static final Set<String> NO_CHECK_URLS = new HashSet<>(Arrays.asList("/login")); // "/login"으로 들어오는 요청은 Filter 작동 X
-
     private final JwtService jwtService;
-    private final MemberRepository memberRepository;
-    private final RedisUtil redisUtil;
-
-    private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
 
 
     @Override
@@ -57,86 +37,24 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
         String accessToken = jwtService.extractAccessToken(request).orElse(null);
         if (jwtService.isTokenValid(accessToken)) {
-            if(redisUtil.hasKeyBlackList(accessToken)) {
-                throw new TokenException(ALREADY_LOGOUT_MEMBER);
-            }
-            getAuthentication(accessToken);
+            jwtService.getAuthentication(accessToken);
             filterChain.doFilter(request, response);
             return;
         }
 
         // Access Token이 만료되어 Refresh Token으로 Access Token 재발급
-        String refreshToken = jwtService.extractRefreshToken(request).orElse(null);
-        if (StringUtils.hasText(accessToken) && jwtService.isTokenValid(refreshToken)) {
-            log.info("AccessToken 재발급");
-            Long id = jwtService.extractId(refreshToken).orElseThrow(() -> new TokenException(INVALID_TOKEN));
-            if (isRefreshTokenMatch(id, refreshToken)) {
-                reIssueRefreshAndAccessToken(response, refreshToken, id);
-            }
-            filterChain.doFilter(request, response);
-            return;
-        }
+//        String refreshToken = jwtService.extractRefreshToken(request).orElse(null);
+//        if (StringUtils.hasText(accessToken) && jwtService.isTokenValid(refreshToken)) {
+//            log.info("AccessToken 재발급");
+//            Long id = jwtService.extractId(refreshToken).orElseThrow(() -> new TokenException(INVALID_TOKEN));
+//            if (isRefreshTokenMatch(id, refreshToken)) {
+//                reIssueRefreshAndAccessToken(response, refreshToken, id);
+//            }
+//            filterChain.doFilter(request, response);
+//            return;
+//        }
 
         log.info("유효한 JWT 토큰이 없습니다. uri: {}, {}", request.getRequestURI(), accessToken);
         filterChain.doFilter(request, response);
-    }
-
-    /**
-     * AccessToken, RefreshToken 재발급 + 인증 + 응답 헤더에 보내기
-     */
-    private void reIssueRefreshAndAccessToken(HttpServletResponse response, String refreshToken, Long id) {
-        String newAccessToken = jwtService.createAccessToken(id);
-        String newRefreshToken = jwtService.createRefreshToken(id);
-        getAuthentication(newAccessToken);
-        redisUtil.delete(id);
-        jwtService.updateRefreshToken(id, newRefreshToken);
-        jwtService.sendAccessAndRefreshToken(response, newAccessToken, refreshToken);
-        log.info("AccessToken, RefreshToken 재발급 완료");
-    }
-
-    /**
-     * RefreshToken 검증 메소드
-     */
-    public boolean isRefreshTokenMatch(Long id, String refreshToken) {
-        log.info("RefreshToken 검증");
-        if (redisUtil.get(id).equals(refreshToken)) {
-            return true;
-        }
-        throw new TokenException(INVALID_TOKEN);
-    }
-
-    /**
-     * [인증 처리 메소드]
-     * 인증 허가 처리된 객체를 SecurityContextHolder에 담기
-     */
-    public void getAuthentication(String accessToken) {
-        log.info("인증 처리 메소드 getAuthentication() 호출");
-        jwtService.extractId(accessToken)
-                .ifPresent(id -> memberRepository.findById(id)
-                        .ifPresent(this::saveAuthentication));
-    }
-
-    /**
-     * [인증 허가 메소드]
-     * 파라미터의 유저 : 우리가 만든 회원 객체 / 빌더의 유저 : UserDetails의 User 객체
-     */
-    public void saveAuthentication(Member member) {
-        log.info("인증 허가 메소드 saveAuthentication() 호출");
-        String password = member.getPassword();
-        if (password == null) { // 소셜 로그인 유저의 비밀번호 임의로 설정 하여 소셜 로그인 유저도 인증 되도록 설정
-            password = PasswordUtil.generateRandomPassword();
-        }
-
-        UserDetails userDetailsUser = org.springframework.security.core.userdetails.User.builder()
-                .username(member.getEmail())
-                .password(password)
-                .roles(member.getRole().name())
-                .build();
-
-        Authentication authentication =
-                new UsernamePasswordAuthenticationToken(userDetailsUser, null,
-                        authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
-
-        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/pawwithu/connectdog/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -1,0 +1,142 @@
+package com.pawwithu.connectdog.jwt.filter;
+
+import com.pawwithu.connectdog.domain.member.entity.Member;
+import com.pawwithu.connectdog.domain.member.repository.MemberRepository;
+import com.pawwithu.connectdog.error.exception.custom.TokenException;
+import com.pawwithu.connectdog.jwt.service.JwtService;
+import com.pawwithu.connectdog.jwt.util.PasswordUtil;
+import com.pawwithu.connectdog.util.RedisUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static com.pawwithu.connectdog.error.ErrorCode.ALREADY_LOGOUT_MEMBER;
+import static com.pawwithu.connectdog.error.ErrorCode.INVALID_TOKEN;
+
+/**
+ * Jwt 인증 필터
+ * "/login" 이외의 URI 요청이 왔을 때 처리하는 필터
+ */
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
+
+    private static final Set<String> NO_CHECK_URLS = new HashSet<>(Arrays.asList("/login")); // "/login"으로 들어오는 요청은 Filter 작동 X
+
+    private final JwtService jwtService;
+    private final MemberRepository memberRepository;
+    private final RedisUtil redisUtil;
+
+    private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        if (NO_CHECK_URLS.stream().anyMatch(url -> url.equals(request.getRequestURI()))) {
+            filterChain.doFilter(request, response); // NO_CHECK_URLS 요청이 들어오면, 다음 필터 호출
+            return;
+        }
+        log.info("uri = {}, query = {}", request.getRequestURI(), request.getQueryString());
+        log.info("JwtAuthenticationProcessingFilter 호출");
+
+        String accessToken = jwtService.extractAccessToken(request).orElse(null);
+        if (jwtService.isTokenValid(accessToken)) {
+            if(redisUtil.hasKeyBlackList(accessToken)) {
+                throw new TokenException(ALREADY_LOGOUT_MEMBER);
+            }
+            getAuthentication(accessToken);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // Access Token이 만료되어 Refresh Token으로 Access Token 재발급
+        String refreshToken = jwtService.extractRefreshToken(request).orElse(null);
+        if (StringUtils.hasText(accessToken) && jwtService.isTokenValid(refreshToken)) {
+            log.info("AccessToken 재발급");
+            Long id = jwtService.extractId(refreshToken).orElseThrow(() -> new TokenException(INVALID_TOKEN));
+            if (isRefreshTokenMatch(id, refreshToken)) {
+                reIssueRefreshAndAccessToken(response, refreshToken, id);
+            }
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        log.info("유효한 JWT 토큰이 없습니다. uri: {}, {}", request.getRequestURI(), accessToken);
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * AccessToken, RefreshToken 재발급 + 인증 + 응답 헤더에 보내기
+     */
+    private void reIssueRefreshAndAccessToken(HttpServletResponse response, String refreshToken, Long id) {
+        String newAccessToken = jwtService.createAccessToken(id);
+        String newRefreshToken = jwtService.createRefreshToken(id);
+        getAuthentication(newAccessToken);
+        redisUtil.delete(id);
+        jwtService.updateRefreshToken(id, newRefreshToken);
+        jwtService.sendAccessAndRefreshToken(response, newAccessToken, refreshToken);
+        log.info("AccessToken, RefreshToken 재발급 완료");
+    }
+
+    /**
+     * RefreshToken 검증 메소드
+     */
+    public boolean isRefreshTokenMatch(Long id, String refreshToken) {
+        log.info("RefreshToken 검증");
+        if (redisUtil.get(id).equals(refreshToken)) {
+            return true;
+        }
+        throw new TokenException(INVALID_TOKEN);
+    }
+
+    /**
+     * [인증 처리 메소드]
+     * 인증 허가 처리된 객체를 SecurityContextHolder에 담기
+     */
+    public void getAuthentication(String accessToken) {
+        log.info("인증 처리 메소드 getAuthentication() 호출");
+        jwtService.extractId(accessToken)
+                .ifPresent(id -> memberRepository.findById(id)
+                        .ifPresent(this::saveAuthentication));
+    }
+
+    /**
+     * [인증 허가 메소드]
+     * 파라미터의 유저 : 우리가 만든 회원 객체 / 빌더의 유저 : UserDetails의 User 객체
+     */
+    public void saveAuthentication(Member member) {
+        log.info("인증 허가 메소드 saveAuthentication() 호출");
+        String password = member.getPassword();
+        if (password == null) { // 소셜 로그인 유저의 비밀번호 임의로 설정 하여 소셜 로그인 유저도 인증 되도록 설정
+            password = PasswordUtil.generateRandomPassword();
+        }
+
+        UserDetails userDetailsUser = org.springframework.security.core.userdetails.User.builder()
+                .username(member.getEmail())
+                .password(password)
+                .roles(member.getRole().name())
+                .build();
+
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(userDetailsUser, null,
+                        authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/jwt/service/JwtService.java
+++ b/src/main/java/com/pawwithu/connectdog/jwt/service/JwtService.java
@@ -1,0 +1,162 @@
+package com.pawwithu.connectdog.jwt.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.pawwithu.connectdog.domain.member.repository.MemberRepository;
+import com.pawwithu.connectdog.util.RedisUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Getter
+@Slf4j
+public class JwtService {
+
+    // 프로퍼티 주입 부분
+    @Value("${jwt.secretKey}")
+    private String secretKey;
+
+    @Value("${jwt.access.expiration}")
+    private Integer accessTokenExpirationPeriod;
+
+    @Value("${jwt.refresh.expiration}")
+    private Integer refreshTokenExpirationPeriod;
+
+    @Value("${jwt.access.header}")
+    private String accessHeader;
+
+    @Value("${jwt.refresh.header}")
+    private String refreshHeader;
+
+    private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
+    private static final String REFRESH_TOKEN_SUBJECT = "RefreshToken";
+    private static final String ID_CLAIM = "id";
+    private static final String BEARER = "Bearer ";
+    private final MemberRepository memberRepository;
+//    private final RedisTemplate<String, String> redisTemplate; // 빈 주입 충돌 -> 명시적으로 주입하면 되지만 여기선 쓰이지 않으므로 주석
+    private final RedisUtil redisUtil;
+
+    // AccessToken & RefreshToken 생성 메소드 부분
+    /**
+     * AccessToken 생성 메소드
+     */
+    public String createAccessToken(Long id) {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject(ACCESS_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + accessTokenExpirationPeriod)) // 토큰 만료 시간 설정
+                .withClaim(ID_CLAIM, id)
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
+    /**
+     * RefreshToken 생성 메소드
+     */
+    public String createRefreshToken(Long id) {
+        Date now = new Date();
+        return JWT.create()
+                .withSubject(REFRESH_TOKEN_SUBJECT)
+                .withExpiresAt(new Date(now.getTime() + refreshTokenExpirationPeriod))
+                .withClaim(ID_CLAIM, id)
+                .sign(Algorithm.HMAC512(secretKey));
+    }
+
+    // AccessToken & RefreshToken Response Header 추가 메소드 부분
+    /**
+     * AccessToken 헤더에 실어서 보내기
+     */
+    public void sendAccessToken(HttpServletResponse response, String accessToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+        response.setHeader(accessHeader, accessToken);
+        log.info("sendAccessToken 메소드 실행");
+    }
+
+    /**
+     * 로그인 시 AccessToken + RefreshToken 헤더에 실어서 보내기
+     */
+    public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
+        response.setStatus(HttpServletResponse.SC_OK);
+        setAccessTokenHeader(response, accessToken);
+        setRefreshTokenHeader(response, refreshToken);
+        log.info("Access Token, Refresh Token 헤더 설정 완료");
+    }
+
+    /**
+     * AccessToken 헤더 설정
+     */
+    public void setAccessTokenHeader(HttpServletResponse response, String accessToken) {
+        response.setHeader(accessHeader, "Bearer " + accessToken);
+    }
+
+    /**
+     * RefreshToken 헤더 설정
+     */
+    public void setRefreshTokenHeader(HttpServletResponse response, String refreshToken) {
+        response.setHeader(refreshHeader, "Bearer " + refreshToken);
+    }
+
+    // 클라이언트의 요청에서 JWT Token, id 추출하는 부분
+    // Bearer XXX에서 Bearer를 제외하고 순수 토큰만 가져오기 위해서, 헤더를 가져온 후 "Bearer"를 삭제(""로 replace)
+    /**
+     * 헤더에서 RefreshToken 추출
+     */
+    public Optional<String> extractRefreshToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(refreshHeader))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    /**
+     * 헤더에서 AccessToken 추출
+     */
+    public Optional<String> extractAccessToken(HttpServletRequest request) {
+        return Optional.ofNullable(request.getHeader(accessHeader))
+                .filter(refreshToken -> refreshToken.startsWith(BEARER))
+                .map(refreshToken -> refreshToken.replace(BEARER, ""));
+    }
+
+    /**
+     * AccessToken에서 Id 추출 -> 유효하지 않다면 빈 Optional 객체 반환
+     */
+    public Optional<Long> extractId(String token) {
+        try {
+            return Optional.ofNullable(JWT.require(Algorithm.HMAC512(secretKey))
+                    .build()
+                    .verify(token)
+                    .getClaim(ID_CLAIM)
+                    .asLong());
+        } catch (Exception e) {
+            log.error("토큰이 유효하지 않습니다.");
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * RefreshToken 저장(업데이트)
+     */
+    public void updateRefreshToken(Long id, String refreshToken) {
+        redisUtil.set(id, refreshToken, refreshTokenExpirationPeriod);
+    }
+
+    /**
+     * 토큰 유효성 검사
+     */
+    public boolean isTokenValid(String token) {
+        try {
+            JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
+            return true;
+        } catch (Exception e) {
+            log.info("유효하지 않은 토큰입니다. {}", e.getMessage());
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/jwt/service/JwtService.java
+++ b/src/main/java/com/pawwithu/connectdog/jwt/service/JwtService.java
@@ -166,10 +166,11 @@ public class JwtService {
      */
     public boolean isTokenValid(String token) {
         try {
+            JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
+
             if(redisUtil.hasKeyBlackList(token)) {
                 throw new TokenException(ALREADY_LOGOUT_MEMBER);
             }
-            JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
             return true;
         } catch (Exception e) {
             log.info("유효하지 않은 토큰입니다. {}", e.getMessage());

--- a/src/main/java/com/pawwithu/connectdog/jwt/service/JwtService.java
+++ b/src/main/java/com/pawwithu/connectdog/jwt/service/JwtService.java
@@ -2,7 +2,10 @@ package com.pawwithu.connectdog.jwt.service;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.pawwithu.connectdog.domain.member.entity.Member;
 import com.pawwithu.connectdog.domain.member.repository.MemberRepository;
+import com.pawwithu.connectdog.error.exception.custom.TokenException;
+import com.pawwithu.connectdog.jwt.util.PasswordUtil;
 import com.pawwithu.connectdog.util.RedisUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -10,10 +13,19 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.authority.mapping.NullAuthoritiesMapper;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 
 import java.util.Date;
 import java.util.Optional;
+
+import static com.pawwithu.connectdog.error.ErrorCode.ALREADY_LOGOUT_MEMBER;
+import static com.pawwithu.connectdog.error.ErrorCode.INVALID_TOKEN;
 
 @Service
 @RequiredArgsConstructor
@@ -44,6 +56,8 @@ public class JwtService {
     private final MemberRepository memberRepository;
 //    private final RedisTemplate<String, String> redisTemplate; // 빈 주입 충돌 -> 명시적으로 주입하면 되지만 여기선 쓰이지 않으므로 주석
     private final RedisUtil redisUtil;
+    private GrantedAuthoritiesMapper authoritiesMapper = new NullAuthoritiesMapper();
+
 
     // AccessToken & RefreshToken 생성 메소드 부분
     /**
@@ -152,11 +166,77 @@ public class JwtService {
      */
     public boolean isTokenValid(String token) {
         try {
+            if(redisUtil.hasKeyBlackList(token)) {
+                throw new TokenException(ALREADY_LOGOUT_MEMBER);
+            }
             JWT.require(Algorithm.HMAC512(secretKey)).build().verify(token);
             return true;
         } catch (Exception e) {
             log.info("유효하지 않은 토큰입니다. {}", e.getMessage());
             return false;
         }
+    }
+
+
+    // 토큰 재발급 시 사용할 메소드
+    /**
+     * AccessToken, RefreshToken 재발급 + 인증 + 응답 헤더에 보내기
+     */
+    private void reIssueRefreshAndAccessToken(HttpServletResponse response, String refreshToken, Long id) {
+        String newAccessToken = createAccessToken(id);
+        String newRefreshToken = createRefreshToken(id);
+        getAuthentication(newAccessToken);
+        redisUtil.delete(id);
+        updateRefreshToken(id, newRefreshToken);
+        sendAccessAndRefreshToken(response, newAccessToken, refreshToken);
+        log.info("AccessToken, RefreshToken 재발급 완료");
+    }
+
+    /**
+     * RefreshToken 검증 메소드
+     */
+    public boolean isRefreshTokenMatch(Long id, String refreshToken) {
+        log.info("RefreshToken 검증");
+        if (redisUtil.get(id).equals(refreshToken)) {
+            return true;
+        }
+        throw new TokenException(INVALID_TOKEN);
+    }
+
+    // 인증 처리/허가 메소드
+
+    /**
+     * [인증 처리 메소드]
+     * 인증 허가 처리된 객체를 SecurityContextHolder에 담기
+     */
+    public void getAuthentication(String accessToken) {
+        log.info("인증 처리 메소드 getAuthentication() 호출");
+        extractId(accessToken)
+                .ifPresent(id -> memberRepository.findById(id)
+                        .ifPresent(this::saveAuthentication));
+    }
+
+    /**
+     * [인증 허가 메소드]
+     * 파라미터의 유저 : 우리가 만든 회원 객체 / 빌더의 유저 : UserDetails의 User 객체
+     */
+    public void saveAuthentication(Member member) {
+        log.info("인증 허가 메소드 saveAuthentication() 호출");
+        String password = member.getPassword();
+        if (password == null) { // 소셜 로그인 유저의 비밀번호 임의로 설정 하여 소셜 로그인 유저도 인증 되도록 설정
+            password = PasswordUtil.generateRandomPassword();
+        }
+
+        UserDetails userDetailsUser = org.springframework.security.core.userdetails.User.builder()
+                .username(member.getEmail())
+                .password(password)
+                .roles(member.getRole().name())
+                .build();
+
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(userDetailsUser, null,
+                        authoritiesMapper.mapAuthorities(userDetailsUser.getAuthorities()));
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/jwt/util/PasswordUtil.java
+++ b/src/main/java/com/pawwithu/connectdog/jwt/util/PasswordUtil.java
@@ -1,0 +1,28 @@
+package com.pawwithu.connectdog.jwt.util;
+
+import java.util.Random;
+
+public class PasswordUtil {
+    public static String generateRandomPassword() {
+        int index = 0;
+        char[] charSet = new char[] {
+                '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+                'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M',
+                'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
+                'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+                'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+        };	// 배열 안의 문자/숫자는 원하는대로
+
+        StringBuffer password = new StringBuffer();
+        Random random = new Random();
+
+        for (int i = 0; i < 8 ; i++) {
+            double rd = random.nextDouble();
+            index = (int) (charSet.length * rd);
+
+            password.append(charSet[index]);
+        }
+        System.out.println(password);
+        return password.toString(); // StringBuffer -> String
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/util/RedisUtil.java
+++ b/src/main/java/com/pawwithu/connectdog/util/RedisUtil.java
@@ -1,0 +1,46 @@
+package com.pawwithu.connectdog.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.TimeUnit;
+
+@Component
+@RequiredArgsConstructor
+public class RedisUtil {
+    private final RedisTemplate<Long, String> redisTemplate;
+    private final RedisTemplate<String, String> redisBlackListTemplate;
+
+    public void set(Long key, String o, Integer minutes) {
+        redisTemplate.opsForValue().set(key, o, minutes, TimeUnit.MINUTES);
+    }
+
+    public String get(Long key) {
+        return redisTemplate.opsForValue().get(key);
+    }
+
+    public boolean delete(Long key) {
+        return redisTemplate.delete(key);
+    }
+
+    public boolean hasKey(Long key) {
+        return redisTemplate.hasKey(key);
+    }
+
+    public void setBlackList(String key, String o, Integer milliSeconds) {
+        redisBlackListTemplate.opsForValue().set(key, o, milliSeconds, TimeUnit.MILLISECONDS);
+    }
+
+    public String getBlackList(String key) {
+        return redisBlackListTemplate.opsForValue().get(key);
+    }
+
+    public boolean deleteBlackList(String key) {
+        return redisBlackListTemplate.delete(key);
+    }
+
+    public boolean hasKeyBlackList(String key) {
+        return redisBlackListTemplate.hasKey(key);
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,3 +28,8 @@ spring:
   sql:
     init:
       mode: always
+
+  data:
+    redis:
+      host: localhost
+      port: 6379

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,5 +1,7 @@
 spring:
   profiles:
+    active:
+      dev
     group:
       local-env:
         - local


### PR DESCRIPTION
## 💡 연관된 이슈
close #11 

## 📝 작업 내용
- Member Entity 생성 (초안)
- SecurityConfig 생성 및 기본 설정
- 자체 회원가입 간단 구현
- application-jwt.yml 추가
- JwtService, JwtAuthenticationProcessingFilter 생성 및 기본 설정
- RedisConfig, RedisUtil 생성 및 기본 설정
- application.yml '.active' 추가

## 💬 리뷰 요구 사항
지금까지 중에는 빠진 부분이 없을까요~?
(Member Entity 들어갈 필드 값은 확정된 와프로 다시 수정해야 합니다 :)
(Claim에 Role 넣었을 때의 장점이 있을지 고민! 그리고 id로도 잘 동작하는지 봐야합니다)

## 기록
- RedisTemplate에서 key, value 타입 설정 시 타입 안정성을 고려하여 Object 반환이 아닌 반환되는 타입을 명확히 하였습니다. 
- Redis 캐시에 저장된 데이터가 오래되거나 더 이상 유효하지 않을 시 자동으로 삭제하는 것이 좋기에 TTL을 사용하여 오래된 캐시 항목을 자동으로 관리하도록 하였습니다. Redis 메모리 사용량을 최적화할 수 있습니다.
- RedisTemplate의 setValueSerializer를 각 메서드에서 다시 설정하지 않아도 됩니다. RedisConfig에서 한 번 설정한 후 변경할 필요는 없다고 합니다.
- RedisTemplate의 타입에 유의하여 사용해야 합니다. Claim 값에 id를 넣어서 Long형 타입을 사용하므로 추후 문제 없이 동작해야 봐야합니다.
