### PR TITLE
[Feature] 닉네임 중복 검사 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/config/SecurityConfig.java
+++ b/src/main/java/com/pawwithu/connectdog/config/SecurityConfig.java
@@ -38,7 +38,8 @@ public class SecurityConfig {
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(request ->
                         request.requestMatchers(mvcMatcherBuilder.pattern("/login")).permitAll()
-                                .requestMatchers(mvcMatcherBuilder.pattern("/sign-up/**")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("volunteers/sign-up/**")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("intermediaries/sign-up/**")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/h2-console/**")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/css/**")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/js/**")).permitAll()
@@ -48,7 +49,7 @@ public class SecurityConfig {
                                 .requestMatchers(mvcMatcherBuilder.pattern("/swagger-ui/**")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/swagger-resources/**")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/v3/api-docs/**")).permitAll()
-                                .requestMatchers(mvcMatcherBuilder.pattern("/members/userName/isDuplicated")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/volunteers/nickname/isDuplicated")).permitAll()
                                 .anyRequest().authenticated())
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(jwtAuthenticationEntryPoint)

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
@@ -16,13 +16,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Sign-Up", description = "Sign-Up API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/sign-up")
 public class SignUpController {
 
     private final AuthService authService;
@@ -34,7 +32,7 @@ public class SignUpController {
                     , description = "1. 이미 존재하는 이메일입니다. \t\n 2. 이미 존재하는 사용자 닉네임입니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
-    @PostMapping
+    @PostMapping("volunteers/sign-up")
     public ResponseEntity<Void> signUp(@RequestBody VolunteerSignUpRequest volunteerSignUpRequest) {
         authService.signUp(volunteerSignUpRequest);
         return ResponseEntity.noContent().build();
@@ -46,7 +44,7 @@ public class SignUpController {
                     , description = "V1, 이메일 형식에 맞지 않습니다. \t\n V1, 이메일은 필수 입력 값입니다. \t\n A1, 이미 존재하는 이메일입니다. \t\n A4, 이메일 인증 코드 전송을 실패했습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
-    @PostMapping("/email")
+    @PostMapping(value = {"/volunteers/sign-up/email", "/intermediaries/sign-up/email"})
     public ResponseEntity<EmailResponse> mailConfirm(@RequestBody @Valid EmailRequest emailRequest){
         EmailResponse emailResponse = emailService.sendEmail(emailRequest);
         return ResponseEntity.ok(emailResponse);

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerController.java
@@ -1,0 +1,37 @@
+package com.pawwithu.connectdog.domain.volunteer.controller;
+
+import com.pawwithu.connectdog.domain.volunteer.dto.request.NicknameRequest;
+import com.pawwithu.connectdog.domain.volunteer.dto.response.NicknameResponse;
+import com.pawwithu.connectdog.domain.volunteer.service.VolunteerService;
+import com.pawwithu.connectdog.error.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Volunteer", description = "Volunteer API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/volunteers")
+public class VolunteerController {
+
+    private final VolunteerService volunteerService;
+
+    @Operation(summary = "닉네임 중복 여부 확인", description = "닉네임 중복 여부를 확인합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "닉네임 중복 여부 확인 성공")
+                    , @ApiResponse(responseCode = "400", description = "V1, 닉네임은 한글, 숫자만 사용가능합니다. \t\n V1, 닉네임은 필수 입력 값입니다. \t\n V1, 2~10자의 닉네임이어야 합니다.", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))})
+    @PostMapping("/nickname/isDuplicated")
+    public ResponseEntity<NicknameResponse> isNicknameDuplicated(@RequestBody @Valid NicknameRequest nickNameRequest) {
+        NicknameResponse response = volunteerService.isNicknameDuplicated(nickNameRequest);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/request/NicknameRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/request/NicknameRequest.java
@@ -1,0 +1,10 @@
+package com.pawwithu.connectdog.domain.volunteer.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record NicknameRequest(@Pattern(regexp = "^[가-힣0-9]*$", message = "닉네임은 한글, 숫자만 사용가능합니다.")
+                              @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+                              @Size(min=2, max=10, message = "2~10자의 닉네임이어야 합니다.")String nickname) {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/response/NicknameResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/response/NicknameResponse.java
@@ -1,0 +1,8 @@
+package com.pawwithu.connectdog.domain.volunteer.dto.response;
+
+public record NicknameResponse(Boolean isDuplicated) {
+
+    public static NicknameResponse of(Boolean isDuplicated){
+        return new NicknameResponse(isDuplicated);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/service/VolunteerService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/service/VolunteerService.java
@@ -1,0 +1,25 @@
+package com.pawwithu.connectdog.domain.volunteer.service;
+
+import com.pawwithu.connectdog.domain.volunteer.dto.request.NicknameRequest;
+import com.pawwithu.connectdog.domain.volunteer.dto.response.NicknameResponse;
+import com.pawwithu.connectdog.domain.volunteer.repository.VolunteerRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class VolunteerService {
+
+    private final VolunteerRepository volunteerRepository;
+
+    @Transactional(readOnly = true)
+    public NicknameResponse isNicknameDuplicated(NicknameRequest nickNameRequest) {
+        Boolean isDuplicated = volunteerRepository.existsByNickname(nickNameRequest.nickname());
+        NicknameResponse response = NicknameResponse.of(isDuplicated);
+        return response;
+    }
+}

--- a/src/test/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerControllerTest.java
@@ -1,0 +1,63 @@
+package com.pawwithu.connectdog.domain.volunteer.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawwithu.connectdog.domain.volunteer.dto.request.NicknameRequest;
+import com.pawwithu.connectdog.domain.volunteer.dto.response.NicknameResponse;
+import com.pawwithu.connectdog.domain.volunteer.service.VolunteerService;
+import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@ExtendWith(MockitoExtension.class)
+class VolunteerControllerTest {
+
+    @InjectMocks
+    private VolunteerController volunteerController;
+    @Mock
+    private VolunteerService volunteerService;
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(volunteerController)
+                .setCustomArgumentResolvers(new TestUserArgumentResolver())
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+
+    @Test
+    void 닉네임_중복_검사() throws Exception {
+        //given
+        NicknameRequest request = new NicknameRequest("코넥독123");
+        NicknameResponse response = new NicknameResponse(false);
+
+        //when
+        given(volunteerService.isNicknameDuplicated(request)).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                post("/volunteers/nickname/isDuplicated")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        //then
+        result.andExpect(status().isOk());
+        verify(volunteerService, times(1)).isNicknameDuplicated(request);
+    }
+}

--- a/src/test/java/com/pawwithu/connectdog/utils/TestUserArgumentResolver.java
+++ b/src/test/java/com/pawwithu/connectdog/utils/TestUserArgumentResolver.java
@@ -1,0 +1,25 @@
+package com.pawwithu.connectdog.utils;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+public class TestUserArgumentResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(UserDetails.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        UserDetails userDetails = mock(UserDetails.class);
+        given(userDetails.getUsername()).willReturn("email");
+        return userDetails;
+    }
+}


### PR DESCRIPTION
## 💡 연관된 이슈
close #19 

## 📝 작업 내용
닉네임 중복 검사 API 구현
- TestUserArgumentResolver 생성
  - TestUserArgumentResolver를 추가한 이유는 Spring Security가 적용된 기능을 테스트할 때 인증 정보를 먼저 주입해줘야 하기 때문인데, 현재 닉네임 중복 검사 API는 필요 없지만 다른 API를 사용할 때는 막힐 것이라 미리 추가했습니다!
- Controller 테스트 코드 추가

## 💬 리뷰 요구 사항