### PR TITLE
[Feature] Spring Security를 이용한 OAuth 2.0(KAKAO, NAVER) 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	// Spring Data Redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	// OAuth2 Client
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	// jwt
 	implementation 'com.auth0:java-jwt:4.2.1'
 	// Validation

--- a/src/main/java/com/pawwithu/connectdog/config/ClientConfig.java
+++ b/src/main/java/com/pawwithu/connectdog/config/ClientConfig.java
@@ -1,0 +1,14 @@
+package com.pawwithu.connectdog.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class ClientConfig {
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/config/SecurityConfig.java
+++ b/src/main/java/com/pawwithu/connectdog/config/SecurityConfig.java
@@ -62,8 +62,9 @@ public class SecurityConfig {
                 .authorizeHttpRequests(request ->
                         request.requestMatchers(mvcMatcherBuilder.pattern("/volunteers/login")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/intermediaries/login")).permitAll()
-                                .requestMatchers(mvcMatcherBuilder.pattern("/volunteers/social-login")).permitAll()
-                                .requestMatchers(mvcMatcherBuilder.pattern("/volunteers/sign-up/**")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/volunteers/login/social")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/volunteers/sign-up")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/volunteers/sign-up/email")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/intermediaries/sign-up/**")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/h2-console/**")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/css/**")).permitAll()

--- a/src/main/java/com/pawwithu/connectdog/config/SecurityConfig.java
+++ b/src/main/java/com/pawwithu/connectdog/config/SecurityConfig.java
@@ -62,6 +62,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(request ->
                         request.requestMatchers(mvcMatcherBuilder.pattern("/volunteers/login")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/intermediaries/login")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/volunteers/social-login")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/volunteers/sign-up/**")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/intermediaries/sign-up/**")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/h2-console/**")).permitAll()

--- a/src/main/java/com/pawwithu/connectdog/config/SecurityConfig.java
+++ b/src/main/java/com/pawwithu/connectdog/config/SecurityConfig.java
@@ -66,6 +66,7 @@ public class SecurityConfig {
                                 .requestMatchers(mvcMatcherBuilder.pattern("/volunteers/sign-up")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/volunteers/sign-up/email")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/intermediaries/sign-up/**")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/reissue-token")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/h2-console/**")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/css/**")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/js/**")).permitAll()

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/AuthController.java
@@ -26,7 +26,7 @@ public class AuthController {
     @Operation(summary = "토큰 재발행", description = "AccessToken, RefreshToken 재발행 합니다.",
             responses = {@ApiResponse(responseCode = "200", description = "토큰 재발행 성공")
                     , @ApiResponse(responseCode = "400"
-                    , description = "V1, 이메일은 필수 전송 값입니다. \t\n T3, 잘못된 토큰입니다. \t\n T5, 해당 RefreshToken을 Redis에서 찾을 수 없습니다."
+                    , description = "V1, RefreshToken은 필수 전송 값입니다. \t\n T3, 잘못된 토큰입니다. \t\n T5, 해당 RefreshToken을 Redis에서 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PostMapping("/reissue-token")

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/AuthController.java
@@ -26,7 +26,7 @@ public class AuthController {
     @Operation(summary = "토큰 재발행", description = "AccessToken, RefreshToken 재발행 합니다.",
             responses = {@ApiResponse(responseCode = "200", description = "토큰 재발행 성공")
                     , @ApiResponse(responseCode = "400"
-                    , description = "T3, 잘못된 토큰입니다. \t\n T5, 해당 RefreshToken을 Redis에서 찾을 수 없습니다."
+                    , description = "V1, 이메일은 필수 전송 값입니다. \t\n T3, 잘못된 토큰입니다. \t\n T5, 해당 RefreshToken을 Redis에서 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PostMapping("/reissue-token")

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/AuthController.java
@@ -1,0 +1,40 @@
+package com.pawwithu.connectdog.domain.auth.controller;
+
+import com.pawwithu.connectdog.domain.auth.dto.request.RefreshTokenRequest;
+import com.pawwithu.connectdog.domain.oauth.dto.response.LoginResponse;
+import com.pawwithu.connectdog.error.dto.ErrorResponse;
+import com.pawwithu.connectdog.jwt.service.JwtService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "Auth API")
+@RestController
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final JwtService jwtService;
+
+    @Operation(summary = "토큰 재발행", description = "AccessToken, RefreshToken 재발행 합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "토큰 재발행 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "T3, 잘못된 토큰입니다. \t\n T5, 해당 RefreshToken을 Redis에서 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @PostMapping("/reissue-token")
+    public ResponseEntity<LoginResponse> reIssueToken(@Valid @RequestBody RefreshTokenRequest request) {
+
+        String refreshToken = request.refreshToken();
+        LoginResponse response = jwtService.reIssueToken(refreshToken);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
@@ -7,7 +7,6 @@ import com.pawwithu.connectdog.domain.auth.dto.request.VolunteerSignUpRequest;
 import com.pawwithu.connectdog.domain.auth.dto.response.EmailResponse;
 import com.pawwithu.connectdog.domain.auth.service.AuthService;
 import com.pawwithu.connectdog.domain.auth.service.EmailService;
-import com.pawwithu.connectdog.domain.oauth.dto.response.LoginResponse;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -15,12 +14,12 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -82,9 +81,9 @@ public class SignUpController {
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PatchMapping("/volunteers/sign-up/social")
-    public ResponseEntity<LoginResponse> volunteerSocialSignUp(@RequestBody SocialSignUpRequest socialSignUpRequest, HttpServletRequest request) {
-        LoginResponse response = authService.volunteerSocialSignUp(socialSignUpRequest, request);
-        return ResponseEntity.ok(response);
+    public ResponseEntity<Void> volunteerSocialSignUp(@AuthenticationPrincipal UserDetails loginUser, @RequestBody SocialSignUpRequest socialSignUpRequest) {
+        authService.volunteerSocialSignUp(loginUser.getUsername(), socialSignUpRequest);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
@@ -2,24 +2,26 @@ package com.pawwithu.connectdog.domain.auth.controller;
 
 import com.pawwithu.connectdog.domain.auth.dto.request.EmailRequest;
 import com.pawwithu.connectdog.domain.auth.dto.request.IntermediarySignUpRequest;
+import com.pawwithu.connectdog.domain.auth.dto.request.SocialSignUpRequest;
 import com.pawwithu.connectdog.domain.auth.dto.request.VolunteerSignUpRequest;
 import com.pawwithu.connectdog.domain.auth.dto.response.EmailResponse;
 import com.pawwithu.connectdog.domain.auth.service.AuthService;
 import com.pawwithu.connectdog.domain.auth.service.EmailService;
+import com.pawwithu.connectdog.domain.oauth.dto.response.LoginResponse;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Sign-Up", description = "Sign-Up API")
@@ -69,6 +71,20 @@ public class SignUpController {
     public ResponseEntity<EmailResponse> mailConfirm(@RequestBody @Valid EmailRequest request){
         EmailResponse emailResponse = emailService.sendEmail(request);
         return ResponseEntity.ok(emailResponse);
+    }
+
+    @Operation(summary = "이동봉사자 소셜 로그인 추가 회원가입", description = "소셜 로그인하는 이동봉사자 추가 회원가입을 합니다.",
+            security = { @SecurityRequirement(name = "bearer-key") },
+            responses = {@ApiResponse(responseCode = "204", description = "이동봉사자 소셜 로그인 추가 회원가입 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "V1, 닉네임은 한글, 숫자만 사용 가능합니다. \t\n V1, 닉네임은 필수 입력 값입니다. \t\n V1, 2~10자의 닉네임이어야 합니다 \t\n A2, 이미 사용 중인 닉네임입니다. \t\n " +
+                    "T3, 잘못된 토큰입니다. \t\n M1, 해당 이동봉사자를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @PatchMapping("/volunteers/sign-up/social")
+    public ResponseEntity<LoginResponse> volunteerSocialSignUp(@RequestBody SocialSignUpRequest socialSignUpRequest, HttpServletRequest request) {
+        LoginResponse response = authService.volunteerSocialSignUp(socialSignUpRequest, request);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
@@ -36,7 +36,7 @@ public class SignUpController {
             responses = {@ApiResponse(responseCode = "204", description = "이동봉사자 자체 회원가입 성공")
                     , @ApiResponse(responseCode = "400"
                     , description = "V1, 이메일 형식에 맞지 않습니다. \t\n V1, 이메일은 필수 입력 값입니다. \t\n V1, 영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상을 입력해 주세요. \t\n " +
-                    "V1, 닉네임은 한글, 숫자만 사용 가능합니다. \t\n V1, 닉네임은 필수 입력 값입니다. \t\n V1, 2~10자의 닉네임이어야 합니다 \t\n A1, 이미 등록된 이메일입니다. \t\n A2, 이미 사용 중인 닉네임입니다."
+                    "V1, 닉네임은 한글, 숫자만 사용 가능합니다. \t\n V1, 닉네임은 필수 입력 값입니다. \t\n V1, 2~10자의 닉네임이어야 합니다. \t\n A1, 이미 등록된 이메일입니다. \t\n A2, 이미 사용 중인 닉네임입니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PostMapping("/volunteers/sign-up")
@@ -77,7 +77,7 @@ public class SignUpController {
             security = { @SecurityRequirement(name = "bearer-key") },
             responses = {@ApiResponse(responseCode = "204", description = "이동봉사자 소셜 로그인 추가 회원가입 성공")
                     , @ApiResponse(responseCode = "400"
-                    , description = "V1, 닉네임은 한글, 숫자만 사용 가능합니다. \t\n V1, 닉네임은 필수 입력 값입니다. \t\n V1, 2~10자의 닉네임이어야 합니다 \t\n A2, 이미 사용 중인 닉네임입니다. \t\n " +
+                    , description = "V1, 닉네임은 한글, 숫자만 사용 가능합니다. \t\n V1, 닉네임은 필수 입력 값입니다. \t\n V1, 2~10자의 닉네임이어야 합니다. \t\n A2, 이미 사용 중인 닉네임입니다. \t\n " +
                     "T3, 잘못된 토큰입니다. \t\n M1, 해당 이동봉사자를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/RefreshTokenRequest.java
@@ -1,4 +1,7 @@
 package com.pawwithu.connectdog.domain.auth.dto.request;
 
-public record RefreshTokenRequest(String refreshToken) {
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshTokenRequest(@NotBlank(message = "이메일은 필수 전송 값입니다.")
+                                  String refreshToken) {
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/RefreshTokenRequest.java
@@ -1,0 +1,4 @@
+package com.pawwithu.connectdog.domain.auth.dto.request;
+
+public record RefreshTokenRequest(String refreshToken) {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/RefreshTokenRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/RefreshTokenRequest.java
@@ -2,6 +2,6 @@ package com.pawwithu.connectdog.domain.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 
-public record RefreshTokenRequest(@NotBlank(message = "이메일은 필수 전송 값입니다.")
+public record RefreshTokenRequest(@NotBlank(message = "RefreshToken은 필수 전송 값입니다.")
                                   String refreshToken) {
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/SocialSignUpRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/SocialSignUpRequest.java
@@ -8,5 +8,7 @@ public record SocialSignUpRequest(
         @Pattern(regexp = "^[가-힣0-9]*$", message = "닉네임은 한글, 숫자만 사용 가능합니다.")
         @NotBlank(message = "닉네임은 필수 입력 값입니다.")
         @Size(min=2, max=10, message = "2~10자의 닉네임이어야 합니다.")
-        String nickname) {
+        String nickname,
+        Integer profileImageNum,
+        Boolean isOptionAgr) {
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/SocialSignUpRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/SocialSignUpRequest.java
@@ -1,0 +1,10 @@
+package com.pawwithu.connectdog.domain.auth.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SocialSignUpRequest(
+        @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+        @Size(min=2, max=10, message = "2~10자의 닉네임이어야 합니다.")
+        String nickName) {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/SocialSignUpRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/SocialSignUpRequest.java
@@ -6,5 +6,5 @@ import jakarta.validation.constraints.Size;
 public record SocialSignUpRequest(
         @NotBlank(message = "닉네임은 필수 입력 값입니다.")
         @Size(min=2, max=10, message = "2~10자의 닉네임이어야 합니다.")
-        String nickName) {
+        String nickname) {
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/SocialSignUpRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/SocialSignUpRequest.java
@@ -1,9 +1,11 @@
 package com.pawwithu.connectdog.domain.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record SocialSignUpRequest(
+        @Pattern(regexp = "^[가-힣0-9]*$", message = "닉네임은 한글, 숫자만 사용 가능합니다.")
         @NotBlank(message = "닉네임은 필수 입력 값입니다.")
         @Size(min=2, max=10, message = "2~10자의 닉네임이어야 합니다.")
         String nickname) {

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/handler/LoginSuccessHandler.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/handler/LoginSuccessHandler.java
@@ -12,7 +12,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -71,7 +70,6 @@ public class LoginSuccessHandler implements AuthenticationSuccessHandler {
         response.setStatus(HttpServletResponse.SC_OK); // 상태 코드를 200 (OK)로 설정
         response.setContentType("application/json");
         response.getWriter().write(new ObjectMapper().writeValueAsString(tokenData));
-
 
         log.info("로그인에 성공하였습니다. 이메일 : {}", email);
         log.info("로그인에 성공하였습니다. AccessToken : {}", accessToken);

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
@@ -74,7 +74,7 @@ public class AuthService {
 
     public LoginResponse volunteerSocialSignUp(SocialSignUpRequest socialSignUpRequest, HttpServletRequest request) {
 
-        if (volunteerRepository.existsByNickname(socialSignUpRequest.nickName())) {
+        if (volunteerRepository.existsByNickname(socialSignUpRequest.nickname())) {
             throw new BadRequestException(ALREADY_EXIST_NICKNAME);
         }
 
@@ -85,7 +85,7 @@ public class AuthService {
         Volunteer volunteer = volunteerRepository.findById(id).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
 
         // 추가 정보 업데이트
-        String nickname = socialSignUpRequest.nickName();
+        String nickname = socialSignUpRequest.nickname();
         volunteer.updateSocialVolunteer(nickname); // AUTH_VOLUNTEER 로 넣어줘야 하는지 확인
 
         // 토큰 재발행

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
@@ -6,15 +6,10 @@ import com.pawwithu.connectdog.domain.auth.dto.request.SocialSignUpRequest;
 import com.pawwithu.connectdog.domain.auth.dto.request.VolunteerSignUpRequest;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
-import com.pawwithu.connectdog.domain.oauth.dto.response.LoginResponse;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import com.pawwithu.connectdog.domain.volunteer.entity.VolunteerRole;
 import com.pawwithu.connectdog.domain.volunteer.repository.VolunteerRepository;
 import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
-import com.pawwithu.connectdog.error.exception.custom.TokenException;
-import com.pawwithu.connectdog.jwt.service.JwtService;
-import com.pawwithu.connectdog.util.RedisUtil;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -34,8 +29,6 @@ public class AuthService {
     private final IntermediaryRepository intermediaryRepository;
     private final PasswordEncoder passwordEncoder;
     private final FileService fileService;
-    private final JwtService jwtService;
-    private final RedisUtil redisUtil;
 
     public void volunteerSignUp(VolunteerSignUpRequest request) {
 
@@ -83,6 +76,8 @@ public class AuthService {
 
         // 추가 정보 업데이트
         String nickname = socialSignUpRequest.nickname();
-        volunteer.updateSocialVolunteer(nickname, VolunteerRole.VOLUNTEER); // GUEST -> VOLUNTEER
+        Integer profileImageNum = socialSignUpRequest.profileImageNum();
+        Boolean isOptionAgr = socialSignUpRequest.isOptionAgr();
+        volunteer.updateSocialVolunteer(nickname, VolunteerRole.VOLUNTEER, profileImageNum, isOptionAgr); // GUEST -> VOLUNTEER
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
@@ -8,13 +8,13 @@ import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
 import com.pawwithu.connectdog.domain.oauth.dto.response.LoginResponse;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
+import com.pawwithu.connectdog.domain.volunteer.entity.VolunteerRole;
 import com.pawwithu.connectdog.domain.volunteer.repository.VolunteerRepository;
 import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
 import com.pawwithu.connectdog.error.exception.custom.TokenException;
 import com.pawwithu.connectdog.jwt.service.JwtService;
 import com.pawwithu.connectdog.util.RedisUtil;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -86,7 +86,7 @@ public class AuthService {
 
         // 추가 정보 업데이트
         String nickname = socialSignUpRequest.nickname();
-        volunteer.updateSocialVolunteer(nickname); // AUTH_VOLUNTEER 로 넣어줘야 하는지 확인
+        volunteer.updateSocialVolunteer(nickname, VolunteerRole.VOLUNTEER); // GUEST -> VOLUNTEER
 
         // 토큰 재발행
         String refreshToken = redisUtil.get(roleName, id);

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/api/KakaoApiClient.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/api/KakaoApiClient.java
@@ -1,0 +1,41 @@
+package com.pawwithu.connectdog.domain.oauth.api;
+
+import com.pawwithu.connectdog.domain.oauth.dto.response.KakaoInfoResponse;
+import com.pawwithu.connectdog.domain.oauth.dto.response.OAuthInfoResponse;
+import com.pawwithu.connectdog.domain.volunteer.entity.SocialType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class KakaoApiClient implements OAuthApiClient {
+    private String apiUrl = "https://kapi.kakao.com";
+    private final RestTemplate restTemplate;
+
+    @Override
+    public SocialType socialType() {
+        return SocialType.KAKAO;
+    }
+
+    @Override
+    public OAuthInfoResponse requestOauthInfo(String accessToken) {
+        String url = apiUrl + "/v2/user/me";
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        httpHeaders.set("Authorization", "Bearer " + accessToken);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+        body.add("property_keys", "[\"id\"]"); // id 값만 받아옴
+
+        HttpEntity<?> request = new HttpEntity<>(body, httpHeaders);
+
+        return restTemplate.postForObject(url, request, KakaoInfoResponse.class);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/api/NaverApiClient.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/api/NaverApiClient.java
@@ -1,0 +1,40 @@
+package com.pawwithu.connectdog.domain.oauth.api;
+
+import com.pawwithu.connectdog.domain.oauth.dto.response.NaverInfoResponse;
+import com.pawwithu.connectdog.domain.oauth.dto.response.OAuthInfoResponse;
+import com.pawwithu.connectdog.domain.volunteer.entity.SocialType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+@RequiredArgsConstructor
+public class NaverApiClient implements OAuthApiClient {
+    private String apiUrl = "https://openapi.naver.com";
+    private final RestTemplate restTemplate;
+
+    @Override
+    public SocialType socialType() {
+        return SocialType.NAVER;
+    }
+
+    @Override
+    public OAuthInfoResponse requestOauthInfo(String accessToken) {
+        String url = apiUrl + "/v1/nid/me";
+
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        httpHeaders.set("Authorization", "Bearer " + accessToken);
+
+        MultiValueMap<String, String> body = new LinkedMultiValueMap<>();
+
+        HttpEntity<?> request = new HttpEntity<>(body, httpHeaders);
+
+        return restTemplate.postForObject(url, request, NaverInfoResponse.class);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/api/OAuthApiClient.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/api/OAuthApiClient.java
@@ -1,0 +1,9 @@
+package com.pawwithu.connectdog.domain.oauth.api;
+
+import com.pawwithu.connectdog.domain.oauth.dto.response.OAuthInfoResponse;
+import com.pawwithu.connectdog.domain.volunteer.entity.SocialType;
+
+public interface OAuthApiClient {
+    SocialType socialType();
+    OAuthInfoResponse requestOauthInfo(String accessToken);
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/controller/OAuthController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/controller/OAuthController.java
@@ -1,0 +1,39 @@
+package com.pawwithu.connectdog.domain.oauth.controller;
+
+import com.pawwithu.connectdog.domain.oauth.dto.request.SocialLoginRequest;
+import com.pawwithu.connectdog.domain.oauth.dto.response.SocialLoginResponse;
+import com.pawwithu.connectdog.domain.oauth.service.OAuthService;
+import com.pawwithu.connectdog.error.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Auth", description = "Auth API")
+@RestController
+@RequiredArgsConstructor
+public class OAuthController {
+
+    private final OAuthService oAuthService;
+
+    @Operation(summary = "이동봉사자 소셜 로그인", description = "이동봉사자 소셜 로그인을 합니다.",
+            responses = {@ApiResponse(responseCode = "204", description = "이동봉사자 소셜 로그인 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = ""
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @PostMapping("/volunteers/social-login")
+    public ResponseEntity<SocialLoginResponse> volunteerSocialLogin(@RequestBody @Valid SocialLoginRequest request) {
+        SocialLoginResponse response = oAuthService.volunteerSocialLogin(request);
+        return ResponseEntity.ok(response);
+    }
+
+    // 소셜 로그인 추가 회원가입 (닉네임 입력) (추가 정보 입력 있나 보기)
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/controller/OAuthController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/controller/OAuthController.java
@@ -26,7 +26,7 @@ public class OAuthController {
     @Operation(summary = "이동봉사자 소셜 로그인", description = "이동봉사자 소셜 로그인을 합니다.",
             responses = {@ApiResponse(responseCode = "204", description = "이동봉사자 소셜 로그인 성공")
                     , @ApiResponse(responseCode = "400"
-                    , description = ""
+                    , description = "V1, AccessToken은 필수 입력 값입니다. \t\n V1, provider는 필수 전송 값입니다. \t\n M1, 해당 이동봉사자를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PostMapping("/volunteers/login/social")

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/controller/OAuthController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/controller/OAuthController.java
@@ -1,7 +1,7 @@
 package com.pawwithu.connectdog.domain.oauth.controller;
 
 import com.pawwithu.connectdog.domain.oauth.dto.request.SocialLoginRequest;
-import com.pawwithu.connectdog.domain.oauth.dto.response.SocialLoginResponse;
+import com.pawwithu.connectdog.domain.oauth.dto.response.LoginResponse;
 import com.pawwithu.connectdog.domain.oauth.service.OAuthService;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Auth", description = "Auth API")
+@Tag(name = "OAuth", description = "OAuth API")
 @RestController
 @RequiredArgsConstructor
 public class OAuthController {
@@ -29,11 +29,10 @@ public class OAuthController {
                     , description = ""
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
-    @PostMapping("/volunteers/social-login")
-    public ResponseEntity<SocialLoginResponse> volunteerSocialLogin(@RequestBody @Valid SocialLoginRequest request) {
-        SocialLoginResponse response = oAuthService.volunteerSocialLogin(request);
+    @PostMapping("/volunteers/login/social")
+    public ResponseEntity<LoginResponse> volunteerSocialLogin(@RequestBody @Valid SocialLoginRequest request) {
+        LoginResponse response = oAuthService.volunteerSocialLogin(request);
         return ResponseEntity.ok(response);
     }
 
-    // 소셜 로그인 추가 회원가입 (닉네임 입력) (추가 정보 입력 있나 보기)
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/request/SocialLoginRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/request/SocialLoginRequest.java
@@ -1,0 +1,6 @@
+package com.pawwithu.connectdog.domain.oauth.dto.request;
+
+import com.pawwithu.connectdog.domain.volunteer.entity.SocialType;
+
+public record SocialLoginRequest(String accessToken, SocialType provider) {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/request/SocialLoginRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/request/SocialLoginRequest.java
@@ -1,6 +1,11 @@
 package com.pawwithu.connectdog.domain.oauth.dto.request;
 
 import com.pawwithu.connectdog.domain.volunteer.entity.SocialType;
+import jakarta.validation.constraints.NotBlank;
 
-public record SocialLoginRequest(String accessToken, SocialType provider) {
+public record SocialLoginRequest(
+        @NotBlank(message = "AccessToken은 필수 전송 값입니다.")
+        String accessToken,
+        @NotBlank(message = "provider는 필수 전송 값입니다.")
+        SocialType provider) {
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/request/SocialLoginRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/request/SocialLoginRequest.java
@@ -2,10 +2,11 @@ package com.pawwithu.connectdog.domain.oauth.dto.request;
 
 import com.pawwithu.connectdog.domain.volunteer.entity.SocialType;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record SocialLoginRequest(
         @NotBlank(message = "AccessToken은 필수 전송 값입니다.")
         String accessToken,
-        @NotBlank(message = "provider는 필수 전송 값입니다.")
+        @NotNull(message = "provider는 필수 전송 값입니다.")
         SocialType provider) {
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/KakaoInfoResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/KakaoInfoResponse.java
@@ -17,6 +17,6 @@ public class KakaoInfoResponse implements OAuthInfoResponse {
     }
     @Override
     public String getId() {
-        return null;
+        return id;
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/KakaoInfoResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/KakaoInfoResponse.java
@@ -1,0 +1,22 @@
+package com.pawwithu.connectdog.domain.oauth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pawwithu.connectdog.domain.volunteer.entity.SocialType;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoInfoResponse implements OAuthInfoResponse {
+    @JsonProperty("id")
+    private String id; // 소셜 식별 값
+
+    @Override
+    public SocialType getSocialType() {
+        return SocialType.KAKAO;
+    }
+    @Override
+    public String getId() {
+        return null;
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/LoginResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/LoginResponse.java
@@ -1,0 +1,7 @@
+package com.pawwithu.connectdog.domain.oauth.dto.response;
+
+public record LoginResponse(String roleName, String accessToken, String refreshToken) {
+    public static LoginResponse of(String roleName, String accessToken, String refreshToken){
+        return new LoginResponse(roleName, accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/NaverInfoResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/NaverInfoResponse.java
@@ -1,0 +1,27 @@
+package com.pawwithu.connectdog.domain.oauth.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pawwithu.connectdog.domain.volunteer.entity.SocialType;
+import lombok.Getter;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class NaverInfoResponse implements OAuthInfoResponse {
+    @JsonProperty("response")
+    private Response response;
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class Response {
+        private String id; // 소셜 식별 값
+    }
+
+    @Override
+    public SocialType getSocialType() {
+        return SocialType.NAVER;
+    }
+    @Override
+    public String getId() {
+        return null;
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/NaverInfoResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/NaverInfoResponse.java
@@ -22,6 +22,6 @@ public class NaverInfoResponse implements OAuthInfoResponse {
     }
     @Override
     public String getId() {
-        return null;
+        return response.getId();
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/OAuthInfoResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/OAuthInfoResponse.java
@@ -1,0 +1,8 @@
+package com.pawwithu.connectdog.domain.oauth.dto.response;
+
+import com.pawwithu.connectdog.domain.volunteer.entity.SocialType;
+
+public interface OAuthInfoResponse {
+    SocialType getSocialType();
+    String getId();
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/SocialLoginResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/SocialLoginResponse.java
@@ -1,0 +1,7 @@
+package com.pawwithu.connectdog.domain.oauth.dto.response;
+
+public record SocialLoginResponse(String roleName, String accessToken, String refreshToken) {
+    public static SocialLoginResponse of(String roleName, String accessToken, String refreshToken){
+        return new SocialLoginResponse(roleName, accessToken, refreshToken);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/SocialLoginResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/dto/response/SocialLoginResponse.java
@@ -1,7 +1,0 @@
-package com.pawwithu.connectdog.domain.oauth.dto.response;
-
-public record SocialLoginResponse(String roleName, String accessToken, String refreshToken) {
-    public static SocialLoginResponse of(String roleName, String accessToken, String refreshToken){
-        return new SocialLoginResponse(roleName, accessToken, refreshToken);
-    }
-}

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/service/OAuthService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/service/OAuthService.java
@@ -1,0 +1,58 @@
+package com.pawwithu.connectdog.domain.oauth.service;
+
+import com.pawwithu.connectdog.domain.oauth.dto.request.SocialLoginRequest;
+import com.pawwithu.connectdog.domain.oauth.dto.response.OAuthInfoResponse;
+import com.pawwithu.connectdog.domain.oauth.dto.response.SocialLoginResponse;
+import com.pawwithu.connectdog.domain.volunteer.entity.SocialType;
+import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
+import com.pawwithu.connectdog.domain.volunteer.entity.VolunteerRole;
+import com.pawwithu.connectdog.domain.volunteer.repository.VolunteerRepository;
+import com.pawwithu.connectdog.jwt.service.JwtService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OAuthService {
+    private final VolunteerRepository volunteerRepository;
+    private final RequestOAuthInfoService requestOAuthInfoService;
+    private final JwtService jwtService;
+
+    public SocialLoginResponse volunteerSocialLogin(SocialLoginRequest request) {
+        OAuthInfoResponse oAuthInfoResponse = requestOAuthInfoService.request(request);
+        SocialType socialType = oAuthInfoResponse.getSocialType();
+        String socialId = oAuthInfoResponse.getId();
+
+        String roleName = "VOLUNTEER";
+        Long id = findOrSaveVolunteer(socialType, socialId); // Volunteer id 반환
+
+        String accessToken = jwtService.createAccessToken(id, roleName);
+        String refreshToken = jwtService.createRefreshToken(id, roleName);
+        jwtService.updateRefreshToken(roleName, id, refreshToken);
+
+        return SocialLoginResponse.of(roleName, accessToken, refreshToken);
+    }
+
+    private Long findOrSaveVolunteer(SocialType socialType, String socialId) {
+
+        Optional<Volunteer> volunteer = volunteerRepository.findBySocialTypeAndSocialId(socialType, socialId);
+
+        if (volunteer.isPresent()) {
+            return volunteer.get().getId();
+        } else {
+            return saveVolunteer(socialType, socialId);
+        }
+    }
+
+    private Long saveVolunteer(SocialType socialType, String socialId) {
+        Volunteer createdVolunteer = new Volunteer("랜덤?", VolunteerRole.VOLUNTEER, socialType, socialId);
+
+        return volunteerRepository.save(createdVolunteer).getId();
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/service/OAuthService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/service/OAuthService.java
@@ -28,9 +28,11 @@ public class OAuthService {
         OAuthInfoResponse oAuthInfoResponse = requestOAuthInfoService.request(request);
         SocialType socialType = oAuthInfoResponse.getSocialType();
         String socialId = oAuthInfoResponse.getId();
+        log.info("socialId: " + socialId);
 
         String roleName = "VOLUNTEER";
         Long id = findOrSaveVolunteer(socialType, socialId); // Volunteer id 반환
+        log.info("id: " + id);
 
         String accessToken = jwtService.createAccessToken(id, roleName);
         String refreshToken = jwtService.createRefreshToken(id, roleName);
@@ -51,7 +53,7 @@ public class OAuthService {
     }
 
     private Long saveVolunteer(SocialType socialType, String socialId) {
-        Volunteer createdVolunteer = new Volunteer("랜덤?", VolunteerRole.VOLUNTEER, socialType, socialId);
+        Volunteer createdVolunteer = new Volunteer(VolunteerRole.VOLUNTEER, socialType, socialId);
 
         return volunteerRepository.save(createdVolunteer).getId();
     }

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/service/OAuthService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/service/OAuthService.java
@@ -1,6 +1,5 @@
 package com.pawwithu.connectdog.domain.oauth.service;
 
-import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.oauth.dto.request.SocialLoginRequest;
 import com.pawwithu.connectdog.domain.oauth.dto.response.OAuthInfoResponse;
 import com.pawwithu.connectdog.domain.oauth.dto.response.LoginResponse;
@@ -16,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
+import java.util.UUID;
 
 import static com.pawwithu.connectdog.error.ErrorCode.VOLUNTEER_NOT_FOUND;
 
@@ -61,7 +61,10 @@ public class OAuthService {
     }
 
     private Long saveVolunteer(SocialType socialType, String socialId) {
-        Volunteer createdVolunteer = new Volunteer(VolunteerRole.GUEST, socialType, socialId);
+        // 소셜 로그인 유저도 loginUser 사용 위한 email 랜덤 저장
+        String email = UUID.randomUUID() + "@socialUser.com";
+        log.info("email: " + email);
+        Volunteer createdVolunteer = new Volunteer(email, VolunteerRole.GUEST, socialType, socialId);
 
         return volunteerRepository.save(createdVolunteer).getId();
     }

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/service/OAuthService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/service/OAuthService.java
@@ -2,7 +2,7 @@ package com.pawwithu.connectdog.domain.oauth.service;
 
 import com.pawwithu.connectdog.domain.oauth.dto.request.SocialLoginRequest;
 import com.pawwithu.connectdog.domain.oauth.dto.response.OAuthInfoResponse;
-import com.pawwithu.connectdog.domain.oauth.dto.response.SocialLoginResponse;
+import com.pawwithu.connectdog.domain.oauth.dto.response.LoginResponse;
 import com.pawwithu.connectdog.domain.volunteer.entity.SocialType;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import com.pawwithu.connectdog.domain.volunteer.entity.VolunteerRole;
@@ -24,7 +24,7 @@ public class OAuthService {
     private final RequestOAuthInfoService requestOAuthInfoService;
     private final JwtService jwtService;
 
-    public SocialLoginResponse volunteerSocialLogin(SocialLoginRequest request) {
+    public LoginResponse volunteerSocialLogin(SocialLoginRequest request) {
         OAuthInfoResponse oAuthInfoResponse = requestOAuthInfoService.request(request);
         SocialType socialType = oAuthInfoResponse.getSocialType();
         String socialId = oAuthInfoResponse.getId();
@@ -36,7 +36,7 @@ public class OAuthService {
         String refreshToken = jwtService.createRefreshToken(id, roleName);
         jwtService.updateRefreshToken(roleName, id, refreshToken);
 
-        return SocialLoginResponse.of(roleName, accessToken, refreshToken);
+        return LoginResponse.of(roleName, accessToken, refreshToken);
     }
 
     private Long findOrSaveVolunteer(SocialType socialType, String socialId) {

--- a/src/main/java/com/pawwithu/connectdog/domain/oauth/service/RequestOAuthInfoService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/oauth/service/RequestOAuthInfoService.java
@@ -1,0 +1,29 @@
+package com.pawwithu.connectdog.domain.oauth.service;
+
+import com.pawwithu.connectdog.domain.oauth.api.OAuthApiClient;
+import com.pawwithu.connectdog.domain.oauth.dto.request.SocialLoginRequest;
+import com.pawwithu.connectdog.domain.oauth.dto.response.OAuthInfoResponse;
+import com.pawwithu.connectdog.domain.volunteer.entity.SocialType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+public class RequestOAuthInfoService {
+    private final Map<SocialType, OAuthApiClient> clients;
+
+    public RequestOAuthInfoService(List<OAuthApiClient> clients) {
+        this.clients = clients.stream().collect(
+                Collectors.toUnmodifiableMap(OAuthApiClient::socialType, Function.identity())
+        );
+    }
+
+    public OAuthInfoResponse request(SocialLoginRequest request) {
+        OAuthApiClient client = clients.get(request.provider());
+        String accessToken = request.accessToken();
+        return client.requestOauthInfo(accessToken);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/SocialType.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/SocialType.java
@@ -1,5 +1,20 @@
 package com.pawwithu.connectdog.domain.volunteer.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
+
+import static com.pawwithu.connectdog.error.ErrorCode.UNKNOWN_PROVIDER;
+
 public enum SocialType {
-    KAKAO, NAVER
+    KAKAO, NAVER;
+
+    @JsonCreator // 이 어노테이션은 Jackson이 JSON에서 객체로 변환할 때 사용
+    public static SocialType fromString(String value) {
+        for (SocialType type : SocialType.values()) {
+            if (type.name().equalsIgnoreCase(value)) {
+                return type;
+            }
+        }
+        throw new BadRequestException(UNKNOWN_PROVIDER);
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
@@ -40,7 +40,8 @@ public class Volunteer {
         this.notification = notification;
     }
 
-    public Volunteer(VolunteerRole role, SocialType socialType, String socialId) {
+    public Volunteer(String email, VolunteerRole role, SocialType socialType, String socialId) {
+        this.email = email;
         this.role = role;
         this.socialType = socialType;
         this.socialId = socialId;

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
@@ -15,7 +15,7 @@ public class Volunteer {
     private Long id;
     private String email; // 이메일
     private String password; // 비밀번호
-    @Column(length = 15, nullable = false)
+    @Column(length = 15)
     private String nickname; // 닉네임
     private Integer profileImageNum;   // 프로필 이미지 번호
     @Column(length = 10)

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
@@ -40,8 +40,7 @@ public class Volunteer {
         this.notification = notification;
     }
 
-    public Volunteer(String nickname, VolunteerRole role, SocialType socialType, String socialId) {
-        this.nickname = nickname;
+    public Volunteer(VolunteerRole role, SocialType socialType, String socialId) {
         this.role = role;
         this.socialType = socialType;
         this.socialId = socialId;

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
@@ -40,6 +40,13 @@ public class Volunteer {
         this.notification = notification;
     }
 
+    public Volunteer(String nickname, VolunteerRole role, SocialType socialType, String socialId) {
+        this.nickname = nickname;
+        this.role = role;
+        this.socialType = socialType;
+        this.socialId = socialId;
+    }
+
     public void passwordEncode(PasswordEncoder passwordEncoder) {
         this.password = passwordEncoder.encode(this.password);
     }

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
@@ -50,7 +50,8 @@ public class Volunteer {
         this.password = passwordEncoder.encode(this.password);
     }
 
-    public void updateSocialVolunteer(String nickname) {
+    public void updateSocialVolunteer(String nickname, VolunteerRole role) {
+        this.role = role;
         this.nickname = nickname;
     }
 

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
@@ -51,4 +51,8 @@ public class Volunteer {
         this.password = passwordEncoder.encode(this.password);
     }
 
+    public void updateSocialVolunteer(String nickname) {
+        this.nickname = nickname;
+    }
+
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
@@ -51,9 +51,11 @@ public class Volunteer {
         this.password = passwordEncoder.encode(this.password);
     }
 
-    public void updateSocialVolunteer(String nickname, VolunteerRole role) {
-        this.role = role;
+    public void updateSocialVolunteer(String nickname, VolunteerRole role, Integer profileImageNum, Boolean isOptionAgr) {
         this.nickname = nickname;
+        this.role = role;
+        this.profileImageNum = profileImageNum;
+        this.isOptionAgr = isOptionAgr;
     }
 
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/VolunteerRole.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/VolunteerRole.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum VolunteerRole {
 
-    VOLUNTEER("ROLE_VOLUNTEER"), AUTH_VOLUNTEER("ROLE_AUTH_VOLUNTEER");
+    GUEST("ROLE_GUEST"), VOLUNTEER("ROLE_VOLUNTEER"), AUTH_VOLUNTEER("ROLE_AUTH_VOLUNTEER");
 
     private final String key;
 

--- a/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
+++ b/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
     TOKEN_IS_EXPIRED("T2", "만료된 토큰입니다."),
     INVALID_TOKEN("T3", "잘못된 토큰입니다."),
     TOKEN_NOT_CREATED("T4", "토큰 생성에 실패했습니다."),
+    TOKEN_NOT_MATCHED("T5", "해당 RefreshToken을 Redis에서 찾을 수 없습니다."),
 
     FILE_NOT_FOUND("F1", "파일이 존재하지 않습니다."),
     INVALID_FILE_UPLOAD("F2", "파일 업로드에 실패했습니다.");

--- a/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
+++ b/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
@@ -11,6 +11,8 @@ public enum ErrorCode {
     ALREADY_EXIST_NICKNAME("A2", "이미 사용 중인 닉네임입니다."),
     ALREADY_LOGOUT_MEMBER("A3", "이미 로그아웃한 회원입니다"),
     EMAIL_SEND_ERROR("A4", "이메일 인증 코드 전송을 실패했습니다."),
+    UNKNOWN_PROVIDER("A4", "provider 값이 KAKAO 또는 NAVER가 아닙니다."),
+
 
     VOLUNTEER_NOT_FOUND("M1", "해당 이동봉사자를 찾을 수 없습니다."), // Member -> M (이동봉사자, 이동봉사 중개 통일)
     INTERMEDIARY_NOT_FOUND("M2", "해당 이동봉사 중개를 찾을 수 없습니다."),

--- a/src/main/java/com/pawwithu/connectdog/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/pawwithu/connectdog/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -23,7 +23,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
     private static final Set<String> NO_CHECK_URLS = new HashSet<>(Arrays.asList(
             "/volunteers/login/social",
-            "/volunteers/login", "/intermediaries/login",
+            "/volunteers/login", "/intermediaries/login", "/reissue-token",
             "/volunteers/sign-up", "/intermediaries/sign-up",
             "/volunteers/sign-up/email")); // 해당 uri로 들어오는 요청은 Filter 작동 X
     private final JwtService jwtService;

--- a/src/main/java/com/pawwithu/connectdog/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/pawwithu/connectdog/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -22,6 +22,7 @@ import java.util.Set;
 public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
     private static final Set<String> NO_CHECK_URLS = new HashSet<>(Arrays.asList(
+            "/volunteers/social-login",
             "/volunteers/login", "/intermediaries/login",
             "/volunteers/sign-up", "/intermediaries/sign-up",
             "/volunteers/sign-up/email")); // 해당 uri로 들어오는 요청은 Filter 작동 X

--- a/src/main/java/com/pawwithu/connectdog/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/com/pawwithu/connectdog/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -22,7 +22,7 @@ import java.util.Set;
 public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
 
     private static final Set<String> NO_CHECK_URLS = new HashSet<>(Arrays.asList(
-            "/volunteers/social-login",
+            "/volunteers/login/social",
             "/volunteers/login", "/intermediaries/login",
             "/volunteers/sign-up", "/intermediaries/sign-up",
             "/volunteers/sign-up/email")); // 해당 uri로 들어오는 요청은 Filter 작동 X

--- a/src/main/java/com/pawwithu/connectdog/jwt/service/JwtService.java
+++ b/src/main/java/com/pawwithu/connectdog/jwt/service/JwtService.java
@@ -207,7 +207,7 @@ public class JwtService {
      */
     public LoginResponse reIssueToken(String refreshToken) {
 
-        // AccessToken 으로 이동봉사자 찾기
+        // AccessToken 으로 이동봉사자 id, roleName 찾기
         Long id = extractId(refreshToken).orElseThrow(() -> new TokenException(INVALID_TOKEN));
         String roleName = extractRoleName(refreshToken).orElseThrow(() -> new TokenException(INVALID_TOKEN));
 
@@ -297,22 +297,15 @@ public class JwtService {
     public void saveVolunteerAuthentication(Volunteer volunteer) {
         log.info("인증 허가 메소드 saveAuthentication() 호출");
         String password = volunteer.getPassword();
-        UserDetails userDetailsUser = null;
         if (password == null) { // 소셜 로그인 유저의 비밀번호 임의로 설정 하여 소셜 로그인 유저도 인증 되도록 설정
             password = PasswordUtil.generateRandomPassword();
-
-            userDetailsUser = org.springframework.security.core.userdetails.User.builder()
-                    .username(volunteer.getSocialId())
-                    .password(password)
-                    .roles(volunteer.getRole().name())
-                    .build();
-        } else {
-            userDetailsUser = org.springframework.security.core.userdetails.User.builder()
-                    .username(volunteer.getEmail())
-                    .password(password)
-                    .roles(volunteer.getRole().name())
-                    .build();
         }
+
+        UserDetails userDetailsUser = org.springframework.security.core.userdetails.User.builder()
+                .username(volunteer.getEmail())
+                .password(password)
+                .roles(volunteer.getRole().name())
+                .build();
 
         Authentication authentication =
                 new UsernamePasswordAuthenticationToken(userDetailsUser, null,

--- a/src/main/java/com/pawwithu/connectdog/jwt/service/JwtService.java
+++ b/src/main/java/com/pawwithu/connectdog/jwt/service/JwtService.java
@@ -302,7 +302,7 @@ public class JwtService {
             password = PasswordUtil.generateRandomPassword();
 
             userDetailsUser = org.springframework.security.core.userdetails.User.builder()
-                    .username(volunteer.getId() + volunteer.getRole().toString())
+                    .username(volunteer.getSocialId())
                     .password(password)
                     .roles(volunteer.getRole().name())
                     .build();

--- a/src/main/java/com/pawwithu/connectdog/jwt/service/JwtService.java
+++ b/src/main/java/com/pawwithu/connectdog/jwt/service/JwtService.java
@@ -297,15 +297,22 @@ public class JwtService {
     public void saveVolunteerAuthentication(Volunteer volunteer) {
         log.info("인증 허가 메소드 saveAuthentication() 호출");
         String password = volunteer.getPassword();
+        UserDetails userDetailsUser = null;
         if (password == null) { // 소셜 로그인 유저의 비밀번호 임의로 설정 하여 소셜 로그인 유저도 인증 되도록 설정
             password = PasswordUtil.generateRandomPassword();
-        }
 
-        UserDetails userDetailsUser = org.springframework.security.core.userdetails.User.builder()
-                .username(volunteer.getEmail())
-                .password(password)
-                .roles(volunteer.getRole().name())
-                .build();
+            userDetailsUser = org.springframework.security.core.userdetails.User.builder()
+                    .username(volunteer.getId() + volunteer.getRole().toString())
+                    .password(password)
+                    .roles(volunteer.getRole().name())
+                    .build();
+        } else {
+            userDetailsUser = org.springframework.security.core.userdetails.User.builder()
+                    .username(volunteer.getEmail())
+                    .password(password)
+                    .roles(volunteer.getRole().name())
+                    .build();
+        }
 
         Authentication authentication =
                 new UsernamePasswordAuthenticationToken(userDetailsUser, null,


### PR DESCRIPTION
## 💡 연관된 이슈
close #29 

## 📝 작업 내용

- OAuth2 Client 의존성 추가
- ClientConfig/OAuthApiClient 인터페이스 추가 
- Kakao/NaverApiClient 컴포넌트 클래스 추가
- OAuthInfoResponse 인터페이스 추가
- Kakao/NaverInfoResponse 클래스 추가
- RequestOAuthInfoService 컴포넌트 클래스 추가
- OAuthController/Service/Dto 추가
- 이동봉사자 소셜 로그인 API 구현
- Jwt 토큰 재발행 API 구현
- 이동봉사자 소셜 로그인 추가 회원가입 API 구현

## 💬 리뷰 요구 사항
- JwtService 인증 허가 메소드 소셜 로그인 분기 처리를 했는데, username으로 socialId 값을 넣어주는 게 문제 없을지 궁금!
- role을 되게 야무지게 사용하고 있는데 (= 여러 군데에서 다양하게) 샥 검토 해주시면 감사하겠습니당 (로컬 테스트는 완료!)