### PR TITLE
[Feature] 도메인별 Entity 추가

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/application/entity/Application.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/entity/Application.java
@@ -1,0 +1,42 @@
+package com.pawwithu.connectdog.domain.application.entity;
+
+import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
+import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
+import com.pawwithu.connectdog.domain.post.entity.Post;
+import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Application extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private ApplicationStatus status; // 신청 상태
+    @Column(length = 10, nullable = false)
+    private String volunteerName; // 이동봉사자 이름
+    @Column(length = 15, nullable = false)
+    private String phone; // 전화번호
+    @Column(length = 10, nullable = false)
+    private String transportation;  // 교통수단
+    @Column(length = 200, nullable = false)
+    private String content; // 신청 내용
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;  // 공고 id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "intermediary_id", nullable = false)
+    private Intermediary intermediary;  // 이동봉사 중개 id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "volunteer_id", nullable = false)
+    private Volunteer volunteer;  // 이동봉사자 id
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/application/entity/ApplicationStatus.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/entity/ApplicationStatus.java
@@ -1,0 +1,13 @@
+package com.pawwithu.connectdog.domain.application.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ApplicationStatus {
+
+    WAITING("대기중"), PROGRESSING("진행중"), COMPLETED("봉사 완료");
+
+    private final String key;
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/badge/entity/Badge.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/badge/entity/Badge.java
@@ -1,0 +1,22 @@
+package com.pawwithu.connectdog.domain.badge.entity;
+
+import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Badge extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(length = 20, nullable = false)
+    private String name; // 뱃지 이름
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/badge/entity/VolunteerBadge.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/badge/entity/VolunteerBadge.java
@@ -1,0 +1,27 @@
+package com.pawwithu.connectdog.domain.badge.entity;
+
+import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
+import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class VolunteerBadge extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "volunteer_id", nullable = false)
+    private Volunteer volunteer; // 이동봉사자 id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "badge_id", nullable = false)
+    private Badge badge; // 뱃지 id
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/bookmark/entity/Bookmark.java
@@ -1,0 +1,27 @@
+package com.pawwithu.connectdog.domain.bookmark.entity;
+
+import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
+import com.pawwithu.connectdog.domain.post.entity.Post;
+import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Bookmark extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;  // 공고 id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "volunteer_id", nullable = false)
+    private Volunteer volunteer;  // 이동봉사자 id
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/dog/entity/Dog.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dog/entity/Dog.java
@@ -1,0 +1,29 @@
+package com.pawwithu.connectdog.domain.dog.entity;
+
+import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Dog extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(length = 10, nullable = false)
+    private String name; // 강아지 이름
+    @Column(nullable = false)
+    private DogSize size; // 강아지 사이즈
+    @Column(nullable = false)
+    private DogGender gender; // 강아지 성별
+    private Float weight; // 강아지 몸무게
+    @Column(length = 200)
+    private String specifics; // 강아지 특이사항
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/dog/entity/DogGender.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dog/entity/DogGender.java
@@ -1,0 +1,14 @@
+package com.pawwithu.connectdog.domain.dog.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DogGender {
+
+    MALE("남아"), FEMALE("여아");
+
+    private final String key;
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/dog/entity/DogSize.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dog/entity/DogSize.java
@@ -1,0 +1,14 @@
+package com.pawwithu.connectdog.domain.dog.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DogSize {
+
+    LARGE("대형견"), MEDIUM("중형견"), SMALL("소형견");
+
+    private final String key;
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/entity/DogStatus.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/entity/DogStatus.java
@@ -1,0 +1,29 @@
+package com.pawwithu.connectdog.domain.dogStatus.entity;
+
+import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
+import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
+import com.pawwithu.connectdog.domain.post.entity.Post;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class DogStatus extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(length = 200, nullable = false)
+    private String content;     // 근황 내용
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post;  // 공고 id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "intermediary_id", nullable = false)
+    private Intermediary intermediary;  // 이동봉사 중개 id
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/entity/DogStatusImage.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/entity/DogStatusImage.java
@@ -1,0 +1,24 @@
+package com.pawwithu.connectdog.domain.dogStatus.entity;
+
+import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class DogStatusImage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String image;   // 근황 사진
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dogStatus_id", nullable = false)
+    private DogStatus dogStatus;  // 근황 id
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/entity/Intermediary.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/entity/Intermediary.java
@@ -1,5 +1,6 @@
 package com.pawwithu.connectdog.domain.intermediary.entity;
 
+import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -8,7 +9,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity
-public class Intermediary {
+public class Intermediary extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/pawwithu/connectdog/domain/post/entity/Post.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/entity/Post.java
@@ -1,0 +1,47 @@
+package com.pawwithu.connectdog.domain.post.entity;
+
+import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
+import com.pawwithu.connectdog.domain.dog.entity.Dog;
+import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Post extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private PostStatus status; // 공고 상태
+    @Column(length = 20, nullable = false)
+    private String departureLoc; // 출발 지역
+    @Column(length = 20, nullable = false)
+    private String arrivalLoc; // 도착 지역
+    @Column(nullable = false)
+    private LocalDateTime startDate; // 봉사 시작 가능 날짜
+    @Column(nullable = false)
+    private LocalDateTime endDate; // 봉사 마감 가능 날짜
+    @Column(length = 10)
+    private String pickUpTime; // 픽업 시간
+    @Column(nullable = false)
+    private Boolean isKennel; // 컨넬 제공 여부
+    @Column(length = 200, nullable = false)
+    private String content; // 이동봉사 설명
+    @Column(nullable = false)
+    private String mainImage; // 대표 이미지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "intermediary_id", nullable = false)
+    private Intermediary intermediary; // 이동봉사 중개 id
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dog_id", nullable = false)
+    private Dog dog; // 강아지 id
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/entity/PostImage.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/entity/PostImage.java
@@ -1,0 +1,24 @@
+package com.pawwithu.connectdog.domain.post.entity;
+
+import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class PostImage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String image; // 강아지 사진
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post; // 공고 id
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/entity/PostStatus.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/entity/PostStatus.java
@@ -1,0 +1,13 @@
+package com.pawwithu.connectdog.domain.post.entity;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostStatus {
+
+    RECRUITING("모집중"), WAITING("승인 대기중"), PROGRESSING("진행중"), COMPLETED("봉사 완료");
+
+    private final String key;
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/review/entity/Review.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/entity/Review.java
@@ -1,0 +1,29 @@
+package com.pawwithu.connectdog.domain.review.entity;
+
+import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
+import com.pawwithu.connectdog.domain.post.entity.Post;
+import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Review extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(length = 200, nullable = false)
+    private String content; // 후기 내용
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id", nullable = false)
+    private Post post; // 공고 id
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "volunteer_id", nullable = false)
+    private Volunteer volunteer; // 이동봉사자 id
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/review/entity/ReviewImage.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/entity/ReviewImage.java
@@ -1,0 +1,24 @@
+package com.pawwithu.connectdog.domain.review.entity;
+
+import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class ReviewImage extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String image; // 후기 사진
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "review_id", nullable = false)
+    private Review review; // 공고 id
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
@@ -1,5 +1,6 @@
 package com.pawwithu.connectdog.domain.volunteer.entity;
 
+import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -8,7 +9,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity
-public class Volunteer {
+public class Volunteer extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 💡 연관된 이슈
close #31 

## 📝 작업 내용
- 도메인별 Entity 추가
- 연관 관계 설정
    - 기존: (이동봉사 후기, 강아지 근황) - (이동봉사 신청)
    - 변경 사항: (이동봉사 후기, 강아지 근황) - (이동봉사 공고)의 연관 관계를 설정함
    
## 💬 리뷰 요구 사항
잘못된 연관 관계 설정이 없는지 봐주시면 좋을 것 같습니다!
