### PR TITLE
[Feature] 이동봉사 중개 공고 등록 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,9 @@ dependencies {
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
 	// AWS S3
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+	// JAXB
+	//implementation 'com.amazonaws:aws-java-sdk-s3:1.12.429'
+	implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/pawwithu/connectdog/common/s3/FileService.java
+++ b/src/main/java/com/pawwithu/connectdog/common/s3/FileService.java
@@ -36,6 +36,7 @@ public class FileService {
         ObjectMetadata metadata = new ObjectMetadata();
 
         try (InputStream inputStream = multipartFile.getInputStream()) {
+            metadata.setContentLength(multipartFile.getSize());
             amazonS3Client.putObject(bucketName, savedFileName, inputStream, metadata);
         } catch (IOException e) {
             log.error("Failed to upload image", e);

--- a/src/main/java/com/pawwithu/connectdog/domain/dog/entity/Dog.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dog/entity/Dog.java
@@ -2,10 +2,7 @@ package com.pawwithu.connectdog.domain.dog.entity;
 
 import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,4 +23,12 @@ public class Dog extends BaseTimeEntity {
     @Column(length = 200)
     private String specifics; // 강아지 특이사항
 
+    @Builder
+    public Dog(String name, DogSize size, DogGender gender, Float weight, String specifics) {
+        this.name = name;
+        this.size = size;
+        this.gender = gender;
+        this.weight = weight;
+        this.specifics = specifics;
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/dog/entity/DogGender.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dog/entity/DogGender.java
@@ -1,13 +1,27 @@
 package com.pawwithu.connectdog.domain.dog.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.stream.Stream;
+
+import static com.pawwithu.connectdog.error.ErrorCode.INVALID_DOG_GENDER;
 
 @Getter
 @RequiredArgsConstructor
 public enum DogGender {
 
     MALE("남아"), FEMALE("여아");
+
+    @JsonCreator
+    public static DogGender create(String requestValue) {
+        return Stream.of(values())
+                .filter(v -> v.key.equalsIgnoreCase(requestValue))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException(INVALID_DOG_GENDER));
+    }
 
     private final String key;
 

--- a/src/main/java/com/pawwithu/connectdog/domain/dog/entity/DogSize.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dog/entity/DogSize.java
@@ -1,13 +1,27 @@
 package com.pawwithu.connectdog.domain.dog.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.stream.Stream;
+
+import static com.pawwithu.connectdog.error.ErrorCode.INVALID_DOG_SIZE;
 
 @Getter
 @RequiredArgsConstructor
 public enum DogSize {
 
-    LARGE("대형견"), MEDIUM("중형견"), SMALL("소형견");
+    SMALL("소형견"), MEDIUM("중형견"), LARGE("대형견");
+
+    @JsonCreator
+    public static DogSize create(String requestValue) {
+        return Stream.of(values())
+                .filter(v -> v.key.equalsIgnoreCase(requestValue))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException(INVALID_DOG_SIZE));
+    }
 
     private final String key;
 

--- a/src/main/java/com/pawwithu/connectdog/domain/dog/repository/DogRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dog/repository/DogRepository.java
@@ -1,0 +1,7 @@
+package com.pawwithu.connectdog.domain.dog.repository;
+
+import com.pawwithu.connectdog.domain.dog.entity.Dog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DogRepository extends JpaRepository<Dog, Long> {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
@@ -1,0 +1,47 @@
+package com.pawwithu.connectdog.domain.post.controller;
+
+import com.pawwithu.connectdog.domain.post.dto.PostCreateRequest;
+import com.pawwithu.connectdog.domain.post.service.PostService;
+import com.pawwithu.connectdog.error.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Tag(name = "Post", description = "Post API")
+@RestController
+@RequiredArgsConstructor
+public class PostController {
+
+    private final PostService postService;
+
+    @Operation(summary = "공고 등록", description = "공고를 등록합니다.",
+            responses = {@ApiResponse(responseCode = "204", description = "공고 등록 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "V1, 출발 지역은 필수 입력 값입니다. \t\n V1, 도착 지역은 필수 입력 값입니다. \t\n " +
+                    "V1, 이동봉사가 필요한 날짜는 필수 입력 값입니다. \t\n V1, 켄넬 제공 여부는 필수 입력 값입니다. \t\n V1, 이동봉사에 대한 설명은 필수 입력 값입니다. \t\n " +
+                    "V1, 강아지 이름은 필수 입력 값입니다. \t\n V1, 강아지 사이즈는 필수 입력 값입니다. \t\n V1, 강아지 성별은 필수 입력 값입니다. \t\n " +
+                    "F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n M2, 해당 이동봉사 중개를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @PostMapping(value = "/intermediaries/posts", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<Void> createPost(@AuthenticationPrincipal UserDetails loginUser,
+                                           @RequestPart @Valid PostCreateRequest request,
+                                           @RequestPart(name = "files", required = false) List<MultipartFile> files) {
+        postService.createPost(loginUser.getUsername(), request, files);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/dto/PostCreateRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/dto/PostCreateRequest.java
@@ -1,0 +1,63 @@
+package com.pawwithu.connectdog.domain.post.dto;
+
+import com.pawwithu.connectdog.domain.dog.entity.Dog;
+import com.pawwithu.connectdog.domain.dog.entity.DogGender;
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
+import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
+import com.pawwithu.connectdog.domain.post.entity.Post;
+import com.pawwithu.connectdog.domain.post.entity.PostStatus;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+public record PostCreateRequest(@NotBlank(message = "출발 지역은 필수 입력 값입니다.")
+                                String departureLoc,
+                                @NotBlank(message = "도착 지역은 필수 입력 값입니다.")
+                                String arrivalLoc,
+                                @NotNull(message = "이동봉사가 필요한 날짜는 필수 입력 값입니다.")
+                                @DateTimeFormat(pattern = "yyyy-MM-dd")
+                                LocalDate startDate,
+                                @NotNull(message = "이동봉사가 필요한 날짜는 필수 입력 값입니다.")
+                                @DateTimeFormat(pattern = "yyyy-MM-dd")
+                                LocalDate endDate,
+                                String pickUpTime,
+                                @NotNull(message = "켄넬 제공 여부는 필수 입력 값입니다.")
+                                Boolean isKennel,
+                                @NotBlank(message = "이동봉사에 대한 설명은 필수 입력 값입니다.")
+                                String content,
+                                @NotBlank(message = "강아지 이름은 필수 입력 값입니다.")
+                                String dogName,
+                                @NotNull(message = "강아지 사이즈는 필수 입력 값입니다.")
+                                DogSize dogSize,
+                                @NotNull(message = "강아지 성별은 필수 입력 값입니다.")
+                                DogGender dogGender,
+                                Float dogWeight,
+                                String specifics) {
+
+        public static Post postToEntity(PostCreateRequest request, Dog dog, Intermediary intermediary) {
+                return Post.builder()
+                        .departureLoc(request.departureLoc)
+                        .arrivalLoc(request.arrivalLoc)
+                        .startDate(request.startDate)
+                        .endDate(request.endDate)
+                        .pickUpTime(request.pickUpTime)
+                        .isKennel(request.isKennel)
+                        .content(request.content)
+                        .status(PostStatus.RECRUITING)
+                        .dog(dog)
+                        .intermediary(intermediary)
+                        .build();
+        }
+
+        public Dog dogToEntity() {
+            return Dog.builder()
+                    .name(dogName)
+                    .size(dogSize)
+                    .gender(dogGender)
+                    .weight(dogWeight)
+                    .specifics(specifics)
+                    .build();
+        }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/entity/Post.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/entity/Post.java
@@ -4,12 +4,9 @@ import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
 import com.pawwithu.connectdog.domain.dog.entity.Dog;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,17 +23,18 @@ public class Post extends BaseTimeEntity {
     @Column(length = 20, nullable = false)
     private String arrivalLoc; // 도착 지역
     @Column(nullable = false)
-    private LocalDateTime startDate; // 봉사 시작 가능 날짜
+    private LocalDate startDate; // 봉사 시작 가능 날짜
     @Column(nullable = false)
-    private LocalDateTime endDate; // 봉사 마감 가능 날짜
+    private LocalDate endDate; // 봉사 마감 가능 날짜
     @Column(length = 10)
     private String pickUpTime; // 픽업 시간
     @Column(nullable = false)
     private Boolean isKennel; // 컨넬 제공 여부
     @Column(length = 200, nullable = false)
     private String content; // 이동봉사 설명
-    @Column(nullable = false)
-    private String mainImage; // 대표 이미지
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mainImage_id")
+    private PostImage mainImage; // 대표 이미지
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "intermediary_id", nullable = false)
     private Intermediary intermediary; // 이동봉사 중개 id
@@ -44,4 +42,21 @@ public class Post extends BaseTimeEntity {
     @JoinColumn(name = "dog_id", nullable = false)
     private Dog dog; // 강아지 id
 
+    @Builder
+    public Post(PostStatus status, String departureLoc, String arrivalLoc, LocalDate startDate, LocalDate endDate, String pickUpTime, Boolean isKennel, String content, Intermediary intermediary, Dog dog) {
+        this.status = status;
+        this.departureLoc = departureLoc;
+        this.arrivalLoc = arrivalLoc;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.pickUpTime = pickUpTime;
+        this.isKennel = isKennel;
+        this.content = content;
+        this.intermediary = intermediary;
+        this.dog = dog;
+    }
+
+    public void updateMainImage(PostImage mainImage) {
+        this.mainImage = mainImage;
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/entity/PostImage.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/entity/PostImage.java
@@ -2,10 +2,7 @@ package com.pawwithu.connectdog.domain.post.entity;
 
 import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,4 +18,10 @@ public class PostImage extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
     private Post post; // 공고 id
+
+    @Builder
+    public PostImage(String image, Post post) {
+        this.image = image;
+        this.post = post;
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/entity/PostStatus.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/entity/PostStatus.java
@@ -1,13 +1,27 @@
 package com.pawwithu.connectdog.domain.post.entity;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+
+import java.util.stream.Stream;
+
+import static com.pawwithu.connectdog.error.ErrorCode.INVALID_POST_STATUS;
 
 @Getter
 @RequiredArgsConstructor
 public enum PostStatus {
 
     RECRUITING("모집중"), WAITING("승인 대기중"), PROGRESSING("진행중"), COMPLETED("봉사 완료");
+
+    @JsonCreator
+    public static PostStatus create(String requestValue) {
+        return Stream.of(values())
+                .filter(v -> v.key.equalsIgnoreCase(requestValue))
+                .findFirst()
+                .orElseThrow(() -> new BadRequestException(INVALID_POST_STATUS));
+    }
 
     private final String key;
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/PostImageRepository.java
@@ -1,0 +1,7 @@
+package com.pawwithu.connectdog.domain.post.repository;
+
+import com.pawwithu.connectdog.domain.post.entity.PostImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/PostRepository.java
@@ -1,0 +1,7 @@
+package com.pawwithu.connectdog.domain.post.repository;
+
+import com.pawwithu.connectdog.domain.post.entity.Post;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/service/PostService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/service/PostService.java
@@ -1,0 +1,66 @@
+package com.pawwithu.connectdog.domain.post.service;
+
+import com.pawwithu.connectdog.common.s3.FileService;
+import com.pawwithu.connectdog.domain.dog.entity.Dog;
+import com.pawwithu.connectdog.domain.dog.repository.DogRepository;
+import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
+import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
+import com.pawwithu.connectdog.domain.post.dto.PostCreateRequest;
+import com.pawwithu.connectdog.domain.post.entity.Post;
+import com.pawwithu.connectdog.domain.post.entity.PostImage;
+import com.pawwithu.connectdog.domain.post.repository.PostImageRepository;
+import com.pawwithu.connectdog.domain.post.repository.PostRepository;
+import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.pawwithu.connectdog.error.ErrorCode.FILE_NOT_FOUND;
+import static com.pawwithu.connectdog.error.ErrorCode.INTERMEDIARY_NOT_FOUND;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PostService {
+
+    private final FileService fileService;
+    private final DogRepository dogRepository;
+    private final IntermediaryRepository intermediaryRepository;
+    private final PostRepository postRepository;
+    private final PostImageRepository postImageRepository;
+
+    public void createPost(String email, PostCreateRequest request, List<MultipartFile> fileList) {
+
+        // 파일이 존재하지 않을 경우
+        if (fileList.isEmpty())
+            throw new BadRequestException(FILE_NOT_FOUND);
+
+        Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
+
+        // 강아지 저장
+        Dog dog = dogRepository.save(request.dogToEntity());
+
+        // 공고 저장 (대표 이미지 제외)
+        Post post = PostCreateRequest.postToEntity(request, dog, intermediary);
+        Post savePost = postRepository.save(post);
+
+        // 공고 이미지 저장
+        List<PostImage> postImages = fileList.stream()
+                .map(f -> PostImage.builder()
+                        .image(fileService.uploadFile(f, "intermediary/post"))
+                        .post(savePost)
+                        .build())
+                .collect(Collectors.toList());
+        postImageRepository.saveAll(postImages);
+
+        // 공고 대표 이미지 업데이트
+        post.updateMainImage(postImages.get(0));
+
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
+++ b/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
@@ -25,7 +25,12 @@ public enum ErrorCode {
     TOKEN_NOT_MATCHED("T5", "해당 RefreshToken을 Redis에서 찾을 수 없습니다."),
 
     FILE_NOT_FOUND("F1", "파일이 존재하지 않습니다."),
-    INVALID_FILE_UPLOAD("F2", "파일 업로드에 실패했습니다.");
+    INVALID_FILE_UPLOAD("F2", "파일 업로드에 실패했습니다."),
+
+    INVALID_DOG_SIZE("D1", "잘못된 강아지 사이즈입니다."),
+    INVALID_DOG_GENDER("D2", "잘못된 강아지 성별입니다."),
+
+    INVALID_POST_STATUS("P1", "잘못된 공고 상태입니다.");
 
 
     private final String code;

--- a/src/test/java/com/pawwithu/connectdog/domain/auth/controller/SignUpControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/auth/controller/SignUpControllerTest.java
@@ -95,6 +95,7 @@ class SignUpControllerTest {
                 "이동봉사 단체",
                 "https://connectdog.site",
                 "안녕하세요 코넥독입니다.",
+                "인스타그램",
                 false);
 
         MockMultipartFile authImage = new MockMultipartFile("authImage", "authImage.png", "multipart/form-data", "uploadFile".getBytes(StandardCharsets.UTF_8));

--- a/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
@@ -1,0 +1,85 @@
+package com.pawwithu.connectdog.domain.post.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.pawwithu.connectdog.domain.dog.entity.DogGender;
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
+import com.pawwithu.connectdog.domain.post.dto.PostCreateRequest;
+import com.pawwithu.connectdog.domain.post.service.PostService;
+import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class PostControllerTest {
+
+    @InjectMocks
+    private PostController postController;
+    @Mock
+    private PostService postService;
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(postController)
+                .setCustomArgumentResolvers(new TestUserArgumentResolver())
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+
+//    @Test
+//    void 이동봉사_중개_공고_등록() throws Exception {
+//        //given
+//        LocalDate startDate = LocalDate.of(2023, 10, 2);
+//        LocalDate endDate = LocalDate.of(2023, 11, 7);
+//        PostCreateRequest postCreateRequest = new PostCreateRequest("서울시 성북구",
+//                "서울시 중랑구",
+//                startDate,
+//                endDate,
+//                "12:00",
+//                true,
+//                "공고 내용",
+//                "봄이",
+//                DogSize.SMALL,
+//                DogGender.FEMALE,
+//                2.1f,
+//                "특이사항");
+//
+//        MockMultipartFile files = new MockMultipartFile("files", "image1.png", "multipart/form-data", "uploadFile".getBytes(StandardCharsets.UTF_8));
+//        MockMultipartFile request = new MockMultipartFile("request", null, "application/json", objectMapper.registerModule(new JavaTimeModule()).writeValueAsString(postCreateRequest).getBytes(StandardCharsets.UTF_8));
+//
+//        //when
+//        ResultActions result = mockMvc.perform(MockMvcRequestBuilders
+//                .multipart(HttpMethod.POST, "/intermediaries/posts")
+//                .file(request)
+//                .file(files)
+//                .accept(MediaType.APPLICATION_JSON)
+//                .contentType(MediaType.MULTIPART_FORM_DATA));
+//
+//        //then
+//        result.andExpect(status().isNoContent());
+//        verify(postService, times(1)).createPost(any(), any(), any());
+//    }
+
+}


### PR DESCRIPTION
## 💡 연관된 이슈
close #35 

## 📝 작업 내용
**Post의 mainImage 필드 -> PostImage를 외래 키로 받도록 변경 (1:1 연관 관계)**
- Post의 mainImage는 String으로 대표 이미지의 url을 담도록 설계했음 (이전)
- PostImage는 한 테이블에서 관리하는 것이 유지보수에 용이함! (이후 공고를 수정할 때 방식을 생각해 봐야 함)
- 따라서 1대1로 Post와 PostImage를 매핑 -> PostImage에 올라간 대표 이미지의 pk를 Post에서 외래 키로 관리하자!

**Enum -> @JsonCreater 적용**
- String으로 들어오는 key값을 Enum값에 매핑해 주기 위함!

**이동봉사 중개 공고 등록 API 구현**
S3에 이미지를 올리는 과정에서 warn 로그 발생
- [S3 warning: "No content length specified for stream data"]
메타 콘텐츠 길이 정해줌 -> 해결
참고 자료 : https://sjparkk-dev1og.tistory.com/m/235

- [JAXB is unavailable. Will fallback to SDK implementation which may be less performant.If you are using Java 9+, you will need to include javax.xml.bind:jaxb-api as a dependency.]
해결하기 위해 아래의 의존성 추가
```
implementation 'com.amazonaws:aws-java-sdk-s3:1.12.429' // S3 서비스와 상호 작용
implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359' // XML 데이터를 자바 객체로 매핑하는 데 사용
```
문제! 💥
aws-java-sdk 의존성을 추가할 경우 아래의 로그 출력됨 . . 
[please remove commons-logging.jar from classpath in order to avoid potential conflicts]
aws-java-sdk 의존성 해제 후 JAXB의 의존성만 추가함!
- 참고 자료:
JAXB
https://github.com/seek-oss/gradle-aws-plugin/issues/15
https://www.roach-dev.com/spring/aws-sdk/

**이동봉사 중개 공고 등록 시 PostImage를 save하는 쿼리가 여러 번 나가는 성능 문제**
현재 PostImage의 List를 만들어 한 번에 saveAll을 하지만 쿼리가 PostImage의 개수만큼 나간다!
-> 벌크 연산을 적용하면 되겠다! batch size를 늘려서 한 번에 할 수 있는 작업을 늘리면 될 것 같다.
하지만 GenerationType.IDENTITY 전략은 데이터 입력 시 엔티티를 먼저 저장하고 식별자를 조회해서 할당하는 방식이기 때문에 벌크 연산이 적용되지 않음 . . 
벌크 연산을 적용하기 위해선 GenerationType.SEQUENCE 또는 GenerationType.TABLE로 설정 변경이 필요!
참고 자료: https://do5do.tistory.com/13


**이동봉사 중개 공고 등록 Controller 테스트 코드 추가**
- Controller 테스트를 했을 때 400이 반환 됨! 일단 주석

## 💬 리뷰 요구 사항
