### PR TITLE
[Feature] 홈 화면 공고 조회 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
+src/main/generated/
 
 ### STS ###
 .apt_generated

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,29 @@ dependencies {
 	// JAXB
 	//implementation 'com.amazonaws:aws-java-sdk-s3:1.12.429'
 	implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+	//querydsl 설정 추가
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+}
+
+// Querydsl 설정부
+def generated = 'src/main/generated'
+
+// querydsl QClass 파일 생성 위치를 지정
+tasks.withType(JavaCompile) {
+	options.getGeneratedSourceOutputDirectory().set(file(generated))
+}
+
+// java source set 에 querydsl QClass 위치 추가
+sourceSets {
+	main.java.srcDirs += [ generated ]
+}
+
+// gradle clean 시에 QClass 디렉토리 삭제
+clean {
+	delete file(generated)
 }
 
 tasks.named('test') {

--- a/src/main/java/com/pawwithu/connectdog/config/QueryDslConfig.java
+++ b/src/main/java/com/pawwithu/connectdog/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package com.pawwithu.connectdog.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @Autowired
+    private EntityManager em;
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(){
+        return new JPAQueryFactory(em);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.pawwithu.connectdog.domain.post.controller;
 
-import com.pawwithu.connectdog.domain.post.dto.PostCreateRequest;
+import com.pawwithu.connectdog.domain.post.dto.request.PostCreateRequest;
+import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
 import com.pawwithu.connectdog.domain.post.service.PostService;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +15,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,5 +45,13 @@ public class PostController {
                                            @RequestPart(name = "files", required = false) List<MultipartFile> files) {
         postService.createPost(loginUser.getUsername(), request, files);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "홈 화면 공고 5개 최신 순 조회", description = "홈 화면에서 공고 5개를 최신 순으로 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "홈 화면 공고 5개 조회 성공")})
+    @GetMapping(value = "/volunteers/posts/home")
+    public ResponseEntity<List<PostGetHomeResponse>> getHomePosts() {
+        List<PostGetHomeResponse> homePosts = postService.getHomePosts();
+        return ResponseEntity.ok(homePosts);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/dto/request/PostCreateRequest.java
@@ -1,4 +1,4 @@
-package com.pawwithu.connectdog.domain.post.dto;
+package com.pawwithu.connectdog.domain.post.dto.request;
 
 import com.pawwithu.connectdog.domain.dog.entity.Dog;
 import com.pawwithu.connectdog.domain.dog.entity.DogGender;

--- a/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostGetHomeResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostGetHomeResponse.java
@@ -1,0 +1,14 @@
+package com.pawwithu.connectdog.domain.post.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+public record PostGetHomeResponse(String mainImage, String departureLoc, String arrivalLoc,
+                                  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                  LocalDate startDate,
+                                  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                  LocalDate endDate,
+                                  String intermediaryName,
+                                  Boolean isKennel) {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
@@ -1,0 +1,10 @@
+package com.pawwithu.connectdog.domain.post.repository;
+
+import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
+
+import java.util.List;
+
+public interface CustomPostRepository {
+
+    List<PostGetHomeResponse> getHomePosts();
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.pawwithu.connectdog.domain.post.repository.impl;
+
+import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
+import com.pawwithu.connectdog.domain.post.repository.CustomPostRepository;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.pawwithu.connectdog.domain.intermediary.entity.QIntermediary.intermediary;
+import static com.pawwithu.connectdog.domain.post.entity.QPost.post;
+import static com.pawwithu.connectdog.domain.post.entity.QPostImage.postImage;
+
+@Repository
+@RequiredArgsConstructor
+public class CustomPostRepositoryImpl implements CustomPostRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<PostGetHomeResponse> getHomePosts() {
+        return queryFactory
+                        .select(Projections.constructor(PostGetHomeResponse.class,
+                                postImage.image, post.departureLoc, post.arrivalLoc, post.startDate, post.endDate,
+                                intermediary.name, post.isKennel))
+                        .from(post)
+                        .join(post.intermediary, intermediary)
+                        .join(post.mainImage, postImage)
+                        .orderBy(post.createdDate.desc())
+                        .limit(5)
+                        .fetch();
+    }
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/service/PostService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/service/PostService.java
@@ -5,9 +5,11 @@ import com.pawwithu.connectdog.domain.dog.entity.Dog;
 import com.pawwithu.connectdog.domain.dog.repository.DogRepository;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
-import com.pawwithu.connectdog.domain.post.dto.PostCreateRequest;
+import com.pawwithu.connectdog.domain.post.dto.request.PostCreateRequest;
+import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
 import com.pawwithu.connectdog.domain.post.entity.Post;
 import com.pawwithu.connectdog.domain.post.entity.PostImage;
+import com.pawwithu.connectdog.domain.post.repository.CustomPostRepository;
 import com.pawwithu.connectdog.domain.post.repository.PostImageRepository;
 import com.pawwithu.connectdog.domain.post.repository.PostRepository;
 import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
@@ -34,6 +36,7 @@ public class PostService {
     private final IntermediaryRepository intermediaryRepository;
     private final PostRepository postRepository;
     private final PostImageRepository postImageRepository;
+    private final CustomPostRepository customPostRepository;
 
     public void createPost(String email, PostCreateRequest request, List<MultipartFile> fileList) {
 
@@ -62,5 +65,10 @@ public class PostService {
         // 공고 대표 이미지 업데이트
         post.updateMainImage(postImages.get(0));
 
+    }
+
+    public List<PostGetHomeResponse> getHomePosts() {
+        List<PostGetHomeResponse> homePosts = customPostRepository.getHomePosts();
+        return homePosts;
     }
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
@@ -1,10 +1,7 @@
 package com.pawwithu.connectdog.domain.post.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.pawwithu.connectdog.domain.dog.entity.DogGender;
-import com.pawwithu.connectdog.domain.dog.entity.DogSize;
-import com.pawwithu.connectdog.domain.post.dto.PostCreateRequest;
+import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
 import com.pawwithu.connectdog.domain.post.service.PostService;
 import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,21 +10,21 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -81,5 +78,27 @@ class PostControllerTest {
 //        result.andExpect(status().isNoContent());
 //        verify(postService, times(1)).createPost(any(), any(), any());
 //    }
+
+    @Test
+    void 홈_공고_5개_조회() throws Exception {
+        //given
+        List<PostGetHomeResponse> response = new ArrayList<>();
+        LocalDate startDate = LocalDate.of(2023, 10, 2);
+        LocalDate endDate = LocalDate.of(2023, 11, 7);
+        response.add(new PostGetHomeResponse("image1", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "이동봉사 중개", true));
+        response.add(new PostGetHomeResponse("image2", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "이동봉사 중개", false));
+
+        //when
+        given(postService.getHomePosts()).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/volunteers/posts/home")
+        );
+
+        //then
+        result.andExpect(status().isOk());
+        verify(postService, times(1)).getHomePosts();
+    }
 
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #37 

## 📝 작업 내용
홈 화면 공고 조회 API 구현
- QueryDsl 관련 설정
- 홈 화면 공고 조회 API 구현
- Controller 테스트 코드 추가

## 💬 리뷰 요구 사항
홈 화면 공고 조회는 다른 공고 목록 조회와 반환하는 값이 겹치지만, 최신 순으로 공고를 보여주고(다른 것은 1. 마감 순 -> 2. 최신 순), 다른 특정한 조건이 없어 API를 따로 만들었습니다! 피드백 부탁드립니다!
QueryDsl 관련해서 수정해야 할 부분 있다면 언제든지 말해주세요!
