### PR TITLE
[Feature] 이동봉사자 공고 북마크 등록 및 삭제 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/bookmark/controller/BookmarkController.java
@@ -6,11 +6,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,16 +24,29 @@ public class BookmarkController {
 
     private final BookmarkService bookmarkService;
 
-    @Operation(summary = "북마크 등록 및 삭제", description = "북마크를 등록하거나 삭제합니다.",
-            responses = {@ApiResponse(responseCode = "204", description = "북마크 등록 및 삭제 성공")
+    @Operation(summary = "북마크 등록", description = "북마크를 등록합니다.",
+            security = { @SecurityRequirement(name = "bearer-key") },
+            responses = {@ApiResponse(responseCode = "204", description = "북마크 등록 성공")
                     , @ApiResponse(responseCode = "400"
                     , description = "M2, 해당 이동봉사자를 찾을 수 없습니다. \t\n P2, 해당 공고를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PostMapping(value = "/volunteers/bookmarks/{postId}")
-    public ResponseEntity<Void> clickBookmark(@AuthenticationPrincipal UserDetails loginUser, @PathVariable("postId") Long postId) {
-        bookmarkService.clickBookmark(loginUser.getUsername(), postId);
+    public ResponseEntity<Void> createBookmark(@AuthenticationPrincipal UserDetails loginUser, @PathVariable("postId") Long postId) {
+        bookmarkService.createBookmark(loginUser.getUsername(), postId);
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "북마크 삭제", description = "북마크를 삭제합니다.",
+            security = { @SecurityRequirement(name = "bearer-key") },
+            responses = {@ApiResponse(responseCode = "204", description = "북마크 삭제 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M2, 해당 이동봉사자를 찾을 수 없습니다. \t\n P2, 해당 공고를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @DeleteMapping(value = "/volunteers/bookmarks/{postId}")
+    public ResponseEntity<Void> deleteBookmark(@AuthenticationPrincipal UserDetails loginUser, @PathVariable("postId") Long postId) {
+        bookmarkService.deleteBookmark(loginUser.getUsername(), postId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/bookmark/controller/BookmarkController.java
@@ -1,0 +1,37 @@
+package com.pawwithu.connectdog.domain.bookmark.controller;
+
+import com.pawwithu.connectdog.domain.bookmark.service.BookmarkService;
+import com.pawwithu.connectdog.error.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Bookmark", description = "Bookmark API")
+@RestController
+@RequiredArgsConstructor
+public class BookmarkController {
+
+    private final BookmarkService bookmarkService;
+
+    @Operation(summary = "북마크 등록 및 삭제", description = "북마크를 등록하거나 삭제합니다.",
+            responses = {@ApiResponse(responseCode = "204", description = "북마크 등록 및 삭제 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M2, 해당 이동봉사자를 찾을 수 없습니다. \t\n P2, 해당 공고를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @PostMapping(value = "/volunteers/bookmarks/{postId}")
+    public ResponseEntity<Void> clickBookmark(@AuthenticationPrincipal UserDetails loginUser, @PathVariable("postId") Long postId) {
+        bookmarkService.clickBookmark(loginUser.getUsername(), postId);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/bookmark/entity/Bookmark.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/bookmark/entity/Bookmark.java
@@ -4,10 +4,7 @@ import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
 import com.pawwithu.connectdog.domain.post.entity.Post;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -24,4 +21,10 @@ public class Bookmark extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "volunteer_id", nullable = false)
     private Volunteer volunteer;  // 이동봉사자 id
+
+    @Builder
+    public Bookmark(Post post, Volunteer volunteer) {
+        this.post = post;
+        this.volunteer = volunteer;
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/bookmark/repository/BookmarkRepository.java
@@ -1,0 +1,13 @@
+package com.pawwithu.connectdog.domain.bookmark.repository;
+
+import com.pawwithu.connectdog.domain.bookmark.entity.Bookmark;
+import com.pawwithu.connectdog.domain.post.entity.Post;
+import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
+
+    void deleteByVolunteerAndPost(Volunteer volunteer, Post post);
+
+    Boolean existsByVolunteerAndPost(Volunteer volunteer, Post post);
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/bookmark/service/BookmarkService.java
@@ -1,0 +1,55 @@
+package com.pawwithu.connectdog.domain.bookmark.service;
+
+import com.pawwithu.connectdog.domain.bookmark.entity.Bookmark;
+import com.pawwithu.connectdog.domain.bookmark.repository.BookmarkRepository;
+import com.pawwithu.connectdog.domain.post.entity.Post;
+import com.pawwithu.connectdog.domain.post.repository.PostRepository;
+import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
+import com.pawwithu.connectdog.domain.volunteer.repository.VolunteerRepository;
+import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.pawwithu.connectdog.error.ErrorCode.POST_NOT_FOUND;
+import static com.pawwithu.connectdog.error.ErrorCode.VOLUNTEER_NOT_FOUND;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BookmarkService {
+
+    private final BookmarkRepository bookmarkRepository;
+    private final VolunteerRepository volunteerRepository;
+    private final PostRepository postRepository;
+
+    public void clickBookmark(String email, Long postId) {
+        Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new BadRequestException(POST_NOT_FOUND));
+
+        if (bookmarkStatus(volunteer, post)) {
+            deleteBookmark(volunteer, post);
+        } else {
+            createBookmark(volunteer, post);
+        }
+    }
+
+    public Boolean bookmarkStatus(Volunteer volunteer, Post post) {
+        return bookmarkRepository.existsByVolunteerAndPost(volunteer, post);
+    }
+
+    public void deleteBookmark(Volunteer volunteer, Post post) {
+        bookmarkRepository.deleteByVolunteerAndPost(volunteer, post);
+    }
+
+    public void createBookmark(Volunteer volunteer, Post post) {
+        Bookmark bookmark = Bookmark.builder()
+                .post(post)
+                .volunteer(volunteer)
+                .build();
+
+        bookmarkRepository.save(bookmark);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
+++ b/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
@@ -30,7 +30,8 @@ public enum ErrorCode {
     INVALID_DOG_SIZE("D1", "잘못된 강아지 사이즈입니다."),
     INVALID_DOG_GENDER("D2", "잘못된 강아지 성별입니다."),
 
-    INVALID_POST_STATUS("P1", "잘못된 공고 상태입니다.");
+    INVALID_POST_STATUS("P1", "잘못된 공고 상태입니다."),
+    POST_NOT_FOUND("P2", "해당 공고를 찾을 수 없습니다.");
 
 
     private final String code;

--- a/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
+++ b/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
@@ -31,7 +31,10 @@ public enum ErrorCode {
     INVALID_DOG_GENDER("D2", "잘못된 강아지 성별입니다."),
 
     INVALID_POST_STATUS("P1", "잘못된 공고 상태입니다."),
-    POST_NOT_FOUND("P2", "해당 공고를 찾을 수 없습니다.");
+    POST_NOT_FOUND("P2", "해당 공고를 찾을 수 없습니다."),
+
+    ALREADY_EXIST_BOOKMARK("B1", "이미 등록된 북마크입니다."),
+    NOT_FOUND_BOOKMARK("B2", "등록되지 않은 북마크입니다.");
 
 
     private final String code;

--- a/src/test/java/com/pawwithu/connectdog/domain/bookmark/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/bookmark/controller/BookmarkControllerTest.java
@@ -1,0 +1,56 @@
+package com.pawwithu.connectdog.domain.bookmark.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawwithu.connectdog.domain.bookmark.service.BookmarkService;
+import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class BookmarkControllerTest {
+
+    @InjectMocks
+    private BookmarkController bookmarkController;
+    @Mock
+    private BookmarkService bookmarkService;
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(bookmarkController)
+                .setCustomArgumentResolvers(new TestUserArgumentResolver())
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+
+    @Test
+    void 이동봉사자_북마크_등록_및_삭제() throws Exception {
+        // given
+        Long postId = 1L;
+
+        // when
+        ResultActions result = mockMvc.perform(
+                post("/volunteers/bookmarks/{postId}", postId)
+        );
+
+        // then
+        result.andExpect(status().isNoContent());
+        verify(bookmarkService, times(1)).clickBookmark(anyString(), anyLong());
+    }
+}

--- a/src/test/java/com/pawwithu/connectdog/domain/bookmark/controller/BookmarkControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/bookmark/controller/BookmarkControllerTest.java
@@ -40,7 +40,7 @@ class BookmarkControllerTest {
     }
 
     @Test
-    void 이동봉사자_북마크_등록_및_삭제() throws Exception {
+    void 이동봉사자_북마크_등록() throws Exception {
         // given
         Long postId = 1L;
 
@@ -51,6 +51,21 @@ class BookmarkControllerTest {
 
         // then
         result.andExpect(status().isNoContent());
-        verify(bookmarkService, times(1)).clickBookmark(anyString(), anyLong());
+        verify(bookmarkService, times(1)).createBookmark(anyString(), anyLong());
+    }
+
+    @Test
+    void 이동봉사자_북마크_삭제() throws Exception {
+        // given
+        Long postId = 1L;
+
+        // when
+        ResultActions result = mockMvc.perform(
+                delete("/volunteers/bookmarks/{postId}", postId)
+        );
+
+        // then
+        result.andExpect(status().isNoContent());
+        verify(bookmarkService, times(1)).deleteBookmark(anyString(), anyLong());
     }
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #39 

## 📝 작업 내용
- 이동봉사자 공고 북마크 등록 API 구현
- 이동봉사자 공고 북마크 삭제 API 구현
- Controller 테스트 코드 추가

## 💬 리뷰 요구 사항
`/volunteers/bookmarks/{postId}`로 uri 결정을 했는데요, 그 이유는! posts를 1 depth로 두고 내려갈까 했지만 그렇게 되면 후기, 근황, 신청도 마찬가지로 되어야 할 것 같은데 그것보다는 그냥 이동봉사자의 북마크하는 행위를 바로 표현하는 게 좋다고 판단했습니다!

테스트 코드를 처음 작성해 봤는데, 한 번 봐주세요! 테스트 데이터를 모두 설정해 주어야 하나 싶었지만, 그게 아닌 Controller 단에서의 테스트만 가능하게 해주는 모듈이 신기합니다! import하는 값에 따라 테스트 코드 작성이 달라지더라구요. 하면서 더 공부해야겠습니다.  
