### PR TITLE
[Feature] 이동봉사 공고 필터 검색 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/common/converter/DogSizeConverter.java
+++ b/src/main/java/com/pawwithu/connectdog/common/converter/DogSizeConverter.java
@@ -1,0 +1,13 @@
+package com.pawwithu.connectdog.common.converter;
+
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.StringUtils;
+
+public class DogSizeConverter implements Converter<String, DogSize> {
+    @Override
+    public DogSize convert(String source) {
+        if (!StringUtils.hasText(source)) return null;
+        return DogSize.create(source);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/common/converter/PostStatusConverter.java
+++ b/src/main/java/com/pawwithu/connectdog/common/converter/PostStatusConverter.java
@@ -1,0 +1,14 @@
+package com.pawwithu.connectdog.common.converter;
+
+import com.pawwithu.connectdog.domain.post.entity.PostStatus;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.util.StringUtils;
+
+public class PostStatusConverter implements Converter<String, PostStatus> {
+    @Override
+    public PostStatus convert(String source) {
+        if (!StringUtils.hasText(source)) return null;
+        return PostStatus.create(source);
+    }
+
+}

--- a/src/main/java/com/pawwithu/connectdog/config/WebConfig.java
+++ b/src/main/java/com/pawwithu/connectdog/config/WebConfig.java
@@ -1,0 +1,17 @@
+package com.pawwithu.connectdog.config;
+
+import com.pawwithu.connectdog.common.converter.DogSizeConverter;
+import com.pawwithu.connectdog.common.converter.PostStatusConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new DogSizeConverter());
+        registry.addConverter(new PostStatusConverter());
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
@@ -1,7 +1,9 @@
 package com.pawwithu.connectdog.domain.post.controller;
 
 import com.pawwithu.connectdog.domain.post.dto.request.PostCreateRequest;
+import com.pawwithu.connectdog.domain.post.dto.request.PostSearchRequest;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
+import com.pawwithu.connectdog.domain.post.dto.response.PostSearchResponse;
 import com.pawwithu.connectdog.domain.post.service.PostService;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,6 +13,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -53,5 +56,17 @@ public class PostController {
     public ResponseEntity<List<PostGetHomeResponse>> getHomePosts() {
         List<PostGetHomeResponse> homePosts = postService.getHomePosts();
         return ResponseEntity.ok(homePosts);
+    }
+
+    @Operation(summary = "공고 필터 검색", description = "공고를 필터로 검색합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "공고 필터 검색 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "P1, 잘못된 공고 상태입니다. \t\n D1, 잘못된 강아지 사이즈입니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping( "/volunteers/posts")
+    public ResponseEntity<List<PostSearchResponse>> searchPosts(PostSearchRequest request, Pageable pageable) {
+        List<PostSearchResponse> response = postService.searchPosts(request, pageable);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/dto/request/PostSearchRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/dto/request/PostSearchRequest.java
@@ -1,0 +1,29 @@
+package com.pawwithu.connectdog.domain.post.dto.request;
+
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
+import com.pawwithu.connectdog.domain.post.entity.PostStatus;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.time.LocalDate;
+
+public record PostSearchRequest(@RequestParam(value = "postStatus", required = false) PostStatus postStatus,
+                                String departureLoc,
+                                String arrivalLoc,
+                                @DateTimeFormat(pattern = "yyyy-MM-dd")
+                                LocalDate startDate,
+                                @DateTimeFormat(pattern = "yyyy-MM-dd")
+                                LocalDate endDate,
+                                @RequestParam(value = "dogSize", required = false) DogSize dogSize,
+                                Boolean isKennel,
+                                String intermediaryName) {
+
+    public PostSearchRequest toEnumStatusAndSize(String postStatus, String dogSize) {
+        PostStatus status = (postStatus != null) ? PostStatus.create(postStatus) : null;
+        DogSize size = (dogSize != null) ? DogSize.create(dogSize) : null;
+        return new PostSearchRequest(
+                status, departureLoc, arrivalLoc,
+                startDate, endDate, size, isKennel, intermediaryName
+        );
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/dto/request/PostSearchRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/dto/request/PostSearchRequest.java
@@ -17,13 +17,5 @@ public record PostSearchRequest(@RequestParam(value = "postStatus", required = f
                                 @RequestParam(value = "dogSize", required = false) DogSize dogSize,
                                 Boolean isKennel,
                                 String intermediaryName) {
-
-    public PostSearchRequest toEnumStatusAndSize(String postStatus, String dogSize) {
-        PostStatus status = (postStatus != null) ? PostStatus.create(postStatus) : null;
-        DogSize size = (dogSize != null) ? DogSize.create(dogSize) : null;
-        return new PostSearchRequest(
-                status, departureLoc, arrivalLoc,
-                startDate, endDate, size, isKennel, intermediaryName
-        );
-    }
+    
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostSearchResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostSearchResponse.java
@@ -1,0 +1,14 @@
+package com.pawwithu.connectdog.domain.post.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+public record PostSearchResponse(String mainImage, String departureLoc, String arrivalLoc,
+                                 @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                 LocalDate startDate,
+                                 @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                 LocalDate endDate,
+                                 String intermediaryName,
+                                 Boolean isKennel) {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/entity/PostStatus.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/entity/PostStatus.java
@@ -13,7 +13,7 @@ import static com.pawwithu.connectdog.error.ErrorCode.INVALID_POST_STATUS;
 @RequiredArgsConstructor
 public enum PostStatus {
 
-    RECRUITING("모집중"), WAITING("승인 대기중"), PROGRESSING("진행중"), COMPLETED("봉사 완료");
+    RECRUITING("모집중"), WAITING("승인 대기중"), PROGRESSING("진행중"), COMPLETED("봉사 완료"), EXPIRED("마감");
 
     @JsonCreator
     public static PostStatus create(String requestValue) {

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
@@ -1,10 +1,14 @@
 package com.pawwithu.connectdog.domain.post.repository;
 
+import com.pawwithu.connectdog.domain.post.dto.request.PostSearchRequest;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
+import com.pawwithu.connectdog.domain.post.dto.response.PostSearchResponse;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
 public interface CustomPostRepository {
 
     List<PostGetHomeResponse> getHomePosts();
+    List<PostSearchResponse> searchPosts(PostSearchRequest request, Pageable pageable);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
@@ -1,14 +1,23 @@
 package com.pawwithu.connectdog.domain.post.repository.impl;
 
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
+import com.pawwithu.connectdog.domain.post.dto.request.PostSearchRequest;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
+import com.pawwithu.connectdog.domain.post.dto.response.PostSearchResponse;
+import com.pawwithu.connectdog.domain.post.entity.PostStatus;
 import com.pawwithu.connectdog.domain.post.repository.CustomPostRepository;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
 
+import java.time.LocalDate;
 import java.util.List;
 
+import static com.pawwithu.connectdog.domain.dog.entity.QDog.dog;
 import static com.pawwithu.connectdog.domain.intermediary.entity.QIntermediary.intermediary;
 import static com.pawwithu.connectdog.domain.post.entity.QPost.post;
 import static com.pawwithu.connectdog.domain.post.entity.QPostImage.postImage;
@@ -31,6 +40,72 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                         .orderBy(post.createdDate.desc())
                         .limit(5)
                         .fetch();
+    }
+
+    @Override
+    public List<PostSearchResponse> searchPosts(PostSearchRequest request, Pageable pageable) {
+        return queryFactory
+                .select(Projections.constructor(PostSearchResponse.class,
+                        postImage.image, post.departureLoc, post.arrivalLoc, post.startDate, post.endDate,
+                        intermediary.name, post.isKennel))
+                .from(post)
+                .join(post.intermediary, intermediary)
+                .join(post.mainImage, postImage)
+                .join(post.dog, dog)
+                .where(allFilterSearch(request, pageable))
+                .orderBy(post.endDate.asc(), post.createdDate.desc())
+                .offset(pageable.getOffset())   // 페이지 번호
+                .limit(pageable.getPageSize())  // 페이지 사이즈
+                .fetch();
+    }
+
+    // 모든 필터 검색
+    private BooleanExpression allFilterSearch(PostSearchRequest request, Pageable pageable) {
+        return postStatusEq(request.postStatus())
+                .and(departureLocContains(request.departureLoc()))
+                .and(arrivalLocContains(request.arrivalLoc()))
+                .and(dateSearch(request.startDate(), request.endDate()))
+                .and(dogSizeEq(request.dogSize()))
+                .and(isKennelEq(request.isKennel()))
+                .and(intermediaryNameContains(request.intermediaryName()));
+    }
+
+    // 공고 상태 필터
+    private BooleanExpression postStatusEq(PostStatus postStatus) {
+        return postStatus == null ? null : post.status.eq(postStatus);
+    }
+
+    // 출발 지역 필터
+    private BooleanExpression departureLocContains(String departureLoc) {
+        return StringUtils.hasText(departureLoc) ? post.departureLoc.contains(departureLoc) : null;
+    }
+
+    // 도착 지역 필터
+    private BooleanExpression arrivalLocContains(String arrivalLoc) {
+        return StringUtils.hasText(arrivalLoc) ? post.arrivalLoc.contains(arrivalLoc) : null;
+    }
+
+    // 일정 필터
+    private BooleanExpression dateSearch(LocalDate userStartDate, LocalDate userEndDate) {
+        if (userStartDate == null || userEndDate == null) return null;
+        return post.startDate.loe(userEndDate).and(post.endDate.goe(userStartDate));
+    }
+
+    // 상세 정보 - 강아지 사이즈 필터
+    private BooleanExpression dogSizeEq(DogSize dogSize) {
+        if (dogSize == null) return null;
+        return dog.size.eq(dogSize);
+    }
+
+    // 상세 정보 - 켄넬 제공 여부 필터
+    private BooleanExpression isKennelEq(Boolean isKennel) {
+        if (isKennel == null) return null;
+        return post.isKennel.eq(isKennel);
+    }
+
+    // 상세 정보 - 이동봉사 중개명 필터
+    private BooleanExpression intermediaryNameContains(String intermediaryName) {
+        return StringUtils.hasText(intermediaryName) ? post.intermediary.name.contains(intermediaryName) : null;
     }
 
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/service/PostService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/service/PostService.java
@@ -6,7 +6,9 @@ import com.pawwithu.connectdog.domain.dog.repository.DogRepository;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
 import com.pawwithu.connectdog.domain.post.dto.request.PostCreateRequest;
+import com.pawwithu.connectdog.domain.post.dto.request.PostSearchRequest;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
+import com.pawwithu.connectdog.domain.post.dto.response.PostSearchResponse;
 import com.pawwithu.connectdog.domain.post.entity.Post;
 import com.pawwithu.connectdog.domain.post.entity.PostImage;
 import com.pawwithu.connectdog.domain.post.repository.CustomPostRepository;
@@ -15,6 +17,7 @@ import com.pawwithu.connectdog.domain.post.repository.PostRepository;
 import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -67,8 +70,15 @@ public class PostService {
 
     }
 
+    @Transactional(readOnly = true)
     public List<PostGetHomeResponse> getHomePosts() {
         List<PostGetHomeResponse> homePosts = customPostRepository.getHomePosts();
         return homePosts;
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostSearchResponse> searchPosts(PostSearchRequest request, Pageable pageable) {
+        List<PostSearchResponse> searchPosts = customPostRepository.searchPosts(request, pageable);
+        return searchPosts;
     }
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #42 

## 📝 작업 내용
- 이동봉사 공고 필터 검색 API 구현
- Converter 추가
스프링이 쿼리 매개변수를 객체로 변환할 때는 @ JsonCreator가 적용되지 않음 (URL에서 전달되는 값이기 때문에 JSON 형식이 아닌 단순한 문자열, 숫자)
@ JsonCreator는 JSON 데이터를 객체로 변환할 때 사용되는데, URL 파라미터는 JSON 형식이 아니므로 적용되지 않는다!
@ RequestParam을 사용할 때 열거형과 같은 특별한 타입에 대한 변환이 필요한 경우, 별도의 컨버터나 변환기를 등록해야 함
-> Converter 등록, WebMvcConfigurer 구현함

**궁금했던 점**
@ RequestBody로 들어오는 Enum 타입에 @ JsonCreater와 Converter 둘다 거치게 된다면 이중 변환 돼서 Exception이 나갈까?
-> @ RequestParam과 @ RequestBody를 함께 사용하는 경우, @ RequestParam은 등록한 컨버터를 통해 문자열을 변환하고, @ RequestBody는 Jackson이 제공하는 기능에 따라 JSON을 객체로 변환됨. 서로 동시에 적용되지 않으며, 서로 다른 매커니즘을 통해 작동한다고 함!
(@ RequestBody를 통해 들어온 JSON 데이터는 스프링의 HttpMessageConverter들에 의해 객체로 변환, 이때 주로 Jackson 라이브러리를 사용하여 JSON 데이터를 Java 객체로 매핑하게 되며, @ JsonCreator 어노테이션은 Jackson에 의해 사용되어 JSON 데이터를 객체로 변환할 때 호출)

- 이동봉사 공고 필터 검색 Controller 테스트 코드 추가

## 💬 리뷰 요구 사항
1. Converter 적용에 있어서 문제가 될 부분이 있을지!
2. 공고 필터 검색이 중요한 기능이라고 생각하는데 성능상 이점을 가져가기 위해서 캐싱 전략을 도입해야 할 것 같음!
-> 이 부분에 있어서는 추후에 생각하더라도 현재 쿼리에 있어 수정할 부분 있는지 봐주시면 감사하겠습니다!
