### PR TITLE
[Feature] 이동봉사자 봉사 후기 등록 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/controller/ReviewController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -30,15 +31,17 @@ public class ReviewController {
     private final ReviewService reviewService;
 
     @Operation(summary = "후기 등록", description = "후기를 등록합니다.",
+            security = { @SecurityRequirement(name = "bearer-key") },
             responses = {@ApiResponse(responseCode = "204", description = "후기 등록 성공")
                     , @ApiResponse(responseCode = "400"
-                    , description = "F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n M2, 해당 이동봉사 중개를 찾을 수 없습니다. \t\n P2, 해당 공고를 찾을 수 없습니다."
+                    , description = "" +
+                    "V1, 20~300자의 내용이어야 합니다. \t\n F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n M2, 해당 이동봉사 중개를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
-    @PostMapping(value = "/volunteers/reviews/{postId}", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    @PostMapping(value = "/volunteers/posts/{postId}/reviews", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     public ResponseEntity<Void> createReview(@AuthenticationPrincipal UserDetails loginUser, @PathVariable("postId") Long postId,
-                                           @RequestPart @Valid ReviewCreateRequest request,
-                                           @RequestPart(name = "files", required = false) List<MultipartFile> files) {
+                                             @RequestPart @Valid ReviewCreateRequest request,
+                                             @RequestPart(name = "files", required = false) List<MultipartFile> files) {
         reviewService.createReview(loginUser.getUsername(), postId, request, files);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/pawwithu/connectdog/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/controller/ReviewController.java
@@ -32,8 +32,7 @@ public class ReviewController {
     @Operation(summary = "후기 등록", description = "후기를 등록합니다.",
             responses = {@ApiResponse(responseCode = "204", description = "후기 등록 성공")
                     , @ApiResponse(responseCode = "400"
-                    , description = "" +
-                    "F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n M2, 해당 이동봉사 중개를 찾을 수 없습니다."
+                    , description = "F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n M2, 해당 이동봉사 중개를 찾을 수 없습니다. \t\n P2, 해당 공고를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PostMapping(value = "/volunteers/reviews/{postId}", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
@@ -43,5 +42,7 @@ public class ReviewController {
         reviewService.createReview(loginUser.getUsername(), postId, request, files);
         return ResponseEntity.noContent().build();
     }
+
+
 
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/controller/ReviewController.java
@@ -1,0 +1,47 @@
+package com.pawwithu.connectdog.domain.review.controller;
+
+import com.pawwithu.connectdog.domain.review.dto.request.ReviewCreateRequest;
+import com.pawwithu.connectdog.domain.review.service.ReviewService;
+import com.pawwithu.connectdog.error.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Tag(name = "Review", description = "Review API")
+@RestController
+@RequiredArgsConstructor
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @Operation(summary = "후기 등록", description = "후기를 등록합니다.",
+            responses = {@ApiResponse(responseCode = "204", description = "후기 등록 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "" +
+                    "F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n M2, 해당 이동봉사 중개를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @PostMapping(value = "/volunteers/reviews/{postId}", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<Void> createReview(@AuthenticationPrincipal UserDetails loginUser, @PathVariable("postId") Long postId,
+                                           @RequestPart @Valid ReviewCreateRequest request,
+                                           @RequestPart(name = "files", required = false) List<MultipartFile> files) {
+        reviewService.createReview(loginUser.getUsername(), postId, request, files);
+        return ResponseEntity.noContent().build();
+    }
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/dto/request/ReviewCreateRequest.java
@@ -1,0 +1,19 @@
+package com.pawwithu.connectdog.domain.review.dto.request;
+
+import com.pawwithu.connectdog.domain.post.entity.Post;
+import com.pawwithu.connectdog.domain.review.entity.Review;
+import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
+import jakarta.validation.constraints.NotBlank;
+
+public record ReviewCreateRequest(@NotBlank(message = "후기 내용은 필수 입력 값입니다.")
+                                  String content) {
+
+    public static Review reviewToEntity(ReviewCreateRequest request, Volunteer volunteer, Post post) {
+        return Review.builder()
+                .content(request.content())
+                .volunteer(volunteer)
+                .post(post)
+                .build();
+    }
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/dto/request/ReviewCreateRequest.java
@@ -4,8 +4,10 @@ import com.pawwithu.connectdog.domain.post.entity.Post;
 import com.pawwithu.connectdog.domain.review.entity.Review;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record ReviewCreateRequest(@NotBlank(message = "후기 내용은 필수 입력 값입니다.")
+                                  @Size(min=20, max=300, message = "20~300자의 내용이어야 합니다.")
                                   String content) {
 
     public static Review reviewToEntity(ReviewCreateRequest request, Volunteer volunteer, Post post) {

--- a/src/main/java/com/pawwithu/connectdog/domain/review/entity/Review.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/entity/Review.java
@@ -2,12 +2,10 @@ package com.pawwithu.connectdog.domain.review.entity;
 
 import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
 import com.pawwithu.connectdog.domain.post.entity.Post;
+import com.pawwithu.connectdog.domain.post.entity.PostImage;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -18,7 +16,7 @@ public class Review extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @Column(length = 200, nullable = false)
+    @Column(length = 300, nullable = false)
     private String content; // 후기 내용
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id", nullable = false)
@@ -26,4 +24,19 @@ public class Review extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "volunteer_id", nullable = false)
     private Volunteer volunteer; // 이동봉사자 id
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mainImage_id")
+    private PostImage mainImage; // 대표 이미지
+
+    @Builder
+    public Review(String content, Post post, Volunteer volunteer, PostImage mainImage) {
+        this.content = content;
+        this.post = post;
+        this.volunteer = volunteer;
+        this.mainImage = mainImage;
+    }
+
+    public void updateMainImage(ReviewImage reviewImage) {
+        this.mainImage = mainImage;
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/review/entity/ReviewImage.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/entity/ReviewImage.java
@@ -2,10 +2,7 @@ package com.pawwithu.connectdog.domain.review.entity;
 
 import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,4 +18,10 @@ public class ReviewImage extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id", nullable = false)
     private Review review; // 공고 id
+
+    @Builder
+    public ReviewImage(String image, Review review) {
+        this.image = image;
+        this.review = review;
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/review/repository/ReviewImageRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/repository/ReviewImageRepository.java
@@ -1,0 +1,7 @@
+package com.pawwithu.connectdog.domain.review.repository;
+
+import com.pawwithu.connectdog.domain.review.entity.ReviewImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.pawwithu.connectdog.domain.review.repository;
+
+import com.pawwithu.connectdog.domain.review.entity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/review/service/ReviewService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/service/ReviewService.java
@@ -1,0 +1,62 @@
+package com.pawwithu.connectdog.domain.review.service;
+
+import com.pawwithu.connectdog.common.s3.FileService;
+import com.pawwithu.connectdog.domain.post.entity.Post;
+import com.pawwithu.connectdog.domain.post.repository.PostRepository;
+import com.pawwithu.connectdog.domain.review.dto.request.ReviewCreateRequest;
+import com.pawwithu.connectdog.domain.review.entity.Review;
+import com.pawwithu.connectdog.domain.review.entity.ReviewImage;
+import com.pawwithu.connectdog.domain.review.repository.ReviewImageRepository;
+import com.pawwithu.connectdog.domain.review.repository.ReviewRepository;
+import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
+import com.pawwithu.connectdog.domain.volunteer.repository.VolunteerRepository;
+import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.pawwithu.connectdog.error.ErrorCode.*;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final FileService fileService;
+    private final VolunteerRepository volunteerRepository;
+    private final PostRepository postRepository;
+    private final ReviewRepository reviewRepository;
+    private final ReviewImageRepository reviewImageRepository;
+
+    public void createReview(String email, Long postId, ReviewCreateRequest request, List<MultipartFile> fileList) {
+
+        // 파일이 존재하지 않을 경우
+        if (fileList.isEmpty())
+            throw new BadRequestException(FILE_NOT_FOUND);
+
+        Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new BadRequestException(POST_NOT_FOUND));
+
+        // 후기 저장 (대표 이미지 제외)
+        Review review = ReviewCreateRequest.reviewToEntity(request, volunteer, post);
+        Review saveReview = reviewRepository.save(review);
+
+        // 후기 이미지 저장
+        List<ReviewImage> reviewImages = fileList.stream()
+                .map(f -> ReviewImage.builder()
+                        .image(fileService.uploadFile(f, "volunteer/review"))
+                        .review(saveReview)
+                        .build())
+                .collect(Collectors.toList());
+        reviewImageRepository.saveAll(reviewImages);
+
+        // 후기 대표 이미지 업데이트
+        review.updateMainImage(reviewImages.get(0));
+    }
+}

--- a/src/test/java/com/pawwithu/connectdog/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/review/controller/ReviewControllerTest.java
@@ -1,0 +1,69 @@
+package com.pawwithu.connectdog.domain.review.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.pawwithu.connectdog.domain.review.dto.request.ReviewCreateRequest;
+import com.pawwithu.connectdog.domain.review.service.ReviewService;
+import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewControllerTest {
+
+    @InjectMocks
+    private ReviewController reviewController;
+    @Mock
+    private ReviewService reviewService;
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(reviewController)
+                .setCustomArgumentResolvers(new TestUserArgumentResolver())
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+
+    @Test
+    void 후기_등록() throws Exception {
+        // given
+        Long postId = 1L;
+        ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest("이동봉사 리뷰입니다.");
+
+        MockMultipartFile files = new MockMultipartFile("files", "image1.png", "multipart/form-data", "uploadFile".getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile request = new MockMultipartFile("request", "", "application/json", objectMapper.registerModule(new JavaTimeModule()).writeValueAsString(reviewCreateRequest).getBytes(StandardCharsets.UTF_8));
+
+        // when
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders
+                .multipart(HttpMethod.POST, "/volunteers/reviews/{postId}", postId)
+                .file(request)
+                .file(files)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.MULTIPART_FORM_DATA));
+
+        // then
+        result.andExpect(status().isNoContent());
+        verify(reviewService, times(1)).createReview(anyString(), anyLong(), any(), any());
+    }
+}


### PR DESCRIPTION
## 💡 연관된 이슈
close #41 

## 📝 작업 내용
- Review에 외래키 제약 조건을 가진 mainImage 필드 추가 후 1:N 연관 관계 설정 추가 (공고 부분 참고)
- 이동봉사자 봉사 후기 등록 API 구현
- 이동봉사자 봉사 후기 등록 Controller 테스트 코드 추가

## 💬 리뷰 요구 사항
- uri의 경우 꼭 depth를 더 타지 않더라도, 의미상으로 이해할 수 있는 범위라고 생각해서 `/volunteers/reviews/{postId}`로 설정했습니다. `/volunteers/reviews` 뒤에 postId, reviewId 두 개가 각각 오더라도 POST, GET으로 구분하면 되지 않을까 하는데 다른 의견 있으시다면 듣고 싶어요.
- 글자수 최대, 최소 Validation은 입력 값을 byte로 변경 후 length를 비교해 준 후 예외 처리 하는 방식을 생각 중인데 DB, UI 상에서 각각 막혀 있는데도 추가 해주어야 한다는 입장인지도! 그리고 다른 방법이 있을지도 알아보면 좋을 것 같아요. Size 어노테이션 속성인 min, max는 list의 size 값인 것 같더라구요. 저도 더 알아보겠습니다.