### PR TITLE
[Feat] 이동봉사 공고 상세 보기 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/bookmark/repository/BookmarkRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/bookmark/repository/BookmarkRepository.java
@@ -10,4 +10,5 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
     void deleteByVolunteerAndPost(Volunteer volunteer, Post post);
 
     Boolean existsByVolunteerAndPost(Volunteer volunteer, Post post);
+    Boolean existsByVolunteerIdAndPostId(Long volunteerId, Long postId);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
@@ -71,7 +71,7 @@ public class PostController {
     @Operation(summary = "공고 상세 보기", description = "공고 상세 정보를 조회합니다.",
             responses = {@ApiResponse(responseCode = "200", description = "공고 상세 정보 조회 성공")
                     , @ApiResponse(responseCode = "400"
-                    , description = "P1, 잘못된 공고 상태입니다. \t\n D1, 잘못된 강아지 사이즈입니다."
+                    , description = "M1, 해당 이동봉사자를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @GetMapping( "/volunteers/posts/{postId}")

--- a/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
@@ -3,6 +3,7 @@ package com.pawwithu.connectdog.domain.post.controller;
 import com.pawwithu.connectdog.domain.post.dto.request.PostCreateRequest;
 import com.pawwithu.connectdog.domain.post.dto.request.PostSearchRequest;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
+import com.pawwithu.connectdog.domain.post.dto.response.PostGetOneResponse;
 import com.pawwithu.connectdog.domain.post.dto.response.PostSearchResponse;
 import com.pawwithu.connectdog.domain.post.service.PostService;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
@@ -18,10 +19,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -68,5 +66,17 @@ public class PostController {
     public ResponseEntity<List<PostSearchResponse>> searchPosts(PostSearchRequest request, Pageable pageable) {
         List<PostSearchResponse> response = postService.searchPosts(request, pageable);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "공고 상세 보기", description = "공고 상세 정보를 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "공고 상세 정보 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "P1, 잘못된 공고 상태입니다. \t\n D1, 잘못된 강아지 사이즈입니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping( "/volunteers/posts/{postId}")
+    public ResponseEntity<PostGetOneResponse> getOnePost(@AuthenticationPrincipal UserDetails loginUser, @PathVariable Long postId) {
+        PostGetOneResponse onePost = postService.getOnePost(loginUser.getUsername(), postId);
+        return ResponseEntity.ok(onePost);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostGetOneResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostGetOneResponse.java
@@ -30,6 +30,7 @@ public record PostGetOneResponse(String mainImage, List<String> images, String p
                 intermediaryId, intermediaryProfileImage, intermediaryName, null);
     }
 
+    // 공고 이미지, 북마크 여부를 포함한 생성자
     public static PostGetOneResponse of(PostGetOneResponse response, List<String> images, Boolean isBookmark) {
         return new PostGetOneResponse(response.mainImage, images, response.postStatus, response.departureLoc, response.arrivalLoc,
                 response.startDate, response.endDate, response.pickUpTime, response.isKennel, response.content,

--- a/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostGetOneResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostGetOneResponse.java
@@ -1,0 +1,40 @@
+package com.pawwithu.connectdog.domain.post.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.pawwithu.connectdog.domain.dog.entity.DogGender;
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
+import com.pawwithu.connectdog.domain.post.entity.PostStatus;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record PostGetOneResponse(String mainImage, List<String> images, String postStatus,
+                                 String departureLoc, String arrivalLoc,
+                                 @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                 LocalDate startDate,
+                                 @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                 LocalDate endDate,
+                                 String pickUpTime,
+                                 Boolean isKennel, String content,
+                                 String dogName, String dogSize, String dogGender, Float dogWeight, String specifics,
+                                 Long intermediaryId, String intermediaryProfileImage, String intermediaryName,
+                                 Boolean isBookmark) {
+
+    // 공고 이미지 필드를 제외한 생성자
+    public PostGetOneResponse(String mainImage, PostStatus postStatus, String departureLoc, String arrivalLoc,
+            LocalDate startDate, LocalDate endDate, String pickUpTime, Boolean isKennel, String content, String dogName,
+            DogSize dogSize, DogGender dogGender, Float dogWeight, String specifics, Long intermediaryId,
+            String intermediaryProfileImage, String intermediaryName) {
+        this(mainImage, null, postStatus.getKey(), departureLoc, arrivalLoc, startDate, endDate,
+                pickUpTime, isKennel, content, dogName, dogSize.getKey(), dogGender.getKey(), dogWeight, specifics,
+                intermediaryId, intermediaryProfileImage, intermediaryName, null);
+    }
+
+    public static PostGetOneResponse of(PostGetOneResponse response, List<String> images, Boolean isBookmark) {
+        return new PostGetOneResponse(response.mainImage, images, response.postStatus, response.departureLoc, response.arrivalLoc,
+                response.startDate, response.endDate, response.pickUpTime, response.isKennel, response.content,
+                response.dogName, response.dogSize, response.dogGender, response.dogWeight, response.specifics,
+                response.intermediaryId, response.intermediaryProfileImage, response.intermediaryName, isBookmark);
+    }
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
@@ -2,6 +2,7 @@ package com.pawwithu.connectdog.domain.post.repository;
 
 import com.pawwithu.connectdog.domain.post.dto.request.PostSearchRequest;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
+import com.pawwithu.connectdog.domain.post.dto.response.PostGetOneResponse;
 import com.pawwithu.connectdog.domain.post.dto.response.PostSearchResponse;
 import org.springframework.data.domain.Pageable;
 
@@ -11,4 +12,6 @@ public interface CustomPostRepository {
 
     List<PostGetHomeResponse> getHomePosts();
     List<PostSearchResponse> searchPosts(PostSearchRequest request, Pageable pageable);
+    PostGetOneResponse getOnePost(Long volunteerId, Long postId);
+    List<String> getOnePostImages(Long postId);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
@@ -10,8 +10,12 @@ import java.util.List;
 
 public interface CustomPostRepository {
 
+    // 홈 화면 공고 5개 조회
     List<PostGetHomeResponse> getHomePosts();
+    // 공고 필터 검색
     List<PostSearchResponse> searchPosts(PostSearchRequest request, Pageable pageable);
-    PostGetOneResponse getOnePost(Long volunteerId, Long postId);
+    // 대표 이미지를 제외한 공고 이미지 조회
     List<String> getOnePostImages(Long postId);
+    // 공고 상세 조회 (대표 이미지를 제외한 다른 이미지 포함 X)
+    PostGetOneResponse getOnePost(Long volunteerId, Long postId);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
@@ -33,6 +33,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
     private final JPAQueryFactory queryFactory;
     private final BookmarkRepository bookmarkRepository;
 
+    // 홈 화면 공고 5개 조회
     @Override
     public List<PostGetHomeResponse> getHomePosts() {
         return queryFactory
@@ -47,6 +48,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                         .fetch();
     }
 
+    // 공고 필터 검색
     @Override
     public List<PostSearchResponse> searchPosts(PostSearchRequest request, Pageable pageable) {
         return queryFactory
@@ -63,6 +65,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                 .fetch();
     }
 
+    // 대표 이미지를 제외한 공고 이미지 조회
     @Override
     public List<String> getOnePostImages(Long postId) {
         return queryFactory
@@ -74,6 +77,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                 .fetch();
     }
 
+    // 공고 상세 조회 (대표 이미지를 제외한 다른 이미지 포함 X)
     @Override
     public PostGetOneResponse getOnePost(Long volunteerId, Long postId) {
         return queryFactory

--- a/src/main/java/com/pawwithu/connectdog/domain/post/service/PostService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/service/PostService.java
@@ -89,8 +89,11 @@ public class PostService {
 
     public PostGetOneResponse getOnePost(String email, Long postId) {
         Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
+        // 공고 조회 (대표 이미지 포함)
         PostGetOneResponse onePost = customPostRepository.getOnePost(volunteer.getId(), postId);
+        // 공고 이미지 조회 (대표 이미지 제외)
         List<String> onePostImages = customPostRepository.getOnePostImages(postId);
+        // 북마크 여부
         Boolean isBookmark = bookmarkRepository.existsByVolunteerIdAndPostId(volunteer.getId(), postId);
         PostGetOneResponse response = PostGetOneResponse.of(onePost, onePostImages, isBookmark);
         return response;

--- a/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
@@ -1,7 +1,10 @@
 package com.pawwithu.connectdog.domain.post.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawwithu.connectdog.domain.dog.entity.DogGender;
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
+import com.pawwithu.connectdog.domain.post.dto.response.PostGetOneResponse;
 import com.pawwithu.connectdog.domain.post.dto.response.PostSearchResponse;
 import com.pawwithu.connectdog.domain.post.service.PostService;
 import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
@@ -23,7 +26,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -136,6 +139,31 @@ class PostControllerTest {
         //then
         result.andExpect(status().isOk());
         verify(postService, times(1)).searchPosts(any(), any());
+    }
+
+    @Test
+    void 공고_상세_보기() throws Exception {
+        //given
+        Long postId = 1L;
+        LocalDate startDate = LocalDate.of(2023, 10, 2);
+        LocalDate endDate = LocalDate.of(2023, 11, 7);
+        List<String> images = new ArrayList<>();
+        images.add("image1");
+        images.add("image2");
+        PostGetOneResponse response = new PostGetOneResponse("mainImage", images, "모집중", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "12:00", true, "이동봉사 공고", "봄이", DogSize.SMALL.getKey(),
+                DogGender.FEMALE.getKey(), 5.1f, "ㄱㅇㅇ", 1L, "profileImage", "이동봉사 중개", true);
+
+
+        //when
+        given(postService.getOnePost(anyString(), anyLong())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/volunteers/posts/{postId}", postId)
+        );
+
+        //then
+        result.andExpect(status().isOk());
+        verify(postService, times(1)).getOnePost(anyString(), anyLong());
     }
 
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #46 

## 📝 작업 내용
- 이동봉사 공고 상세 보기 API 구현
- 이동봉사 공고 상세 보기 Controller 테스트 코드 추가

공고 상세 보기 시 조회되는 값들을 한 번에 처리해도 괜찮을까? 에 대한 고민에 대한 결론
- CustomPostRepositoryImpl에서 PostImage와 Post에 대한 조인을 수행 (관련된 엔티티 간의 조인 로직이 한 장소에서 중앙 집중화되어 유지보수가 쉬워짐)
- 코드가 너무 복잡해지거나 단일 책임 원칙을 위반하는 것 같다면, 더 작은 단위로 Repository를 분리 (북마크 여부와 같이 직접적으로 관련된 엔티티라고 생각되지 않다면 분리함)

## 💬 리뷰 요구 사항
현재 공고의 정보들을 불러오는 과정에 있어서 효율적이지 않거나, 수정을 했으면 좋겠다하는 부분이 있다면 언제든지 말해주세요!