### PR TITLE
[Feature] 이동봉사자 봉사 후기 단건 조회 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
@@ -81,7 +81,7 @@ public class SignUpController {
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PatchMapping("/volunteers/sign-up/social")
-    public ResponseEntity<Void> volunteerSocialSignUp(@AuthenticationPrincipal UserDetails loginUser, @RequestBody SocialSignUpRequest socialSignUpRequest) {
+    public ResponseEntity<Void> volunteerSocialSignUp(@AuthenticationPrincipal UserDetails loginUser, @RequestBody @Valid SocialSignUpRequest socialSignUpRequest) {
         authService.volunteerSocialSignUp(loginUser.getUsername(), socialSignUpRequest);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/pawwithu/connectdog/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/controller/ReviewController.java
@@ -1,6 +1,7 @@
 package com.pawwithu.connectdog.domain.review.controller;
 
 import com.pawwithu.connectdog.domain.review.dto.request.ReviewCreateRequest;
+import com.pawwithu.connectdog.domain.review.dto.response.ReviewGetResponse;
 import com.pawwithu.connectdog.domain.review.service.ReviewService;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,10 +16,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestPart;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -34,8 +32,7 @@ public class ReviewController {
             security = { @SecurityRequirement(name = "bearer-key") },
             responses = {@ApiResponse(responseCode = "204", description = "후기 등록 성공")
                     , @ApiResponse(responseCode = "400"
-                    , description = "" +
-                    "V1, 20~300자의 내용이어야 합니다. \t\n F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n M2, 해당 이동봉사 중개를 찾을 수 없습니다."
+                    , description = "V1, 20~300자의 내용이어야 합니다. \t\n F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n M2, 해당 이동봉사 중개를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PostMapping(value = "/volunteers/posts/{postId}/reviews", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
@@ -46,6 +43,18 @@ public class ReviewController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "후기 단건 조회", description = "후기 단건 조회합니다.",
+            security = { @SecurityRequirement(name = "bearer-key") },
+            responses = { @ApiResponse(responseCode = "200", description = "후기 단건 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M1, 해당 이동봉사자를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping("/volunteers/reviews/{reviewId}")
+    public ResponseEntity<ReviewGetResponse> getOneReview(@AuthenticationPrincipal UserDetails loginUser, @PathVariable Long reviewId) {
+        ReviewGetResponse response = reviewService.getOneReview(loginUser.getUsername(), reviewId);
+        return ResponseEntity.ok(response);
+    }
 
 
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/review/dto/response/ReviewGetResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/dto/response/ReviewGetResponse.java
@@ -1,0 +1,29 @@
+package com.pawwithu.connectdog.domain.review.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record ReviewGetResponse(String dogName, String volunteerNickname, String mainImage, List<String> images,
+                                @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                LocalDate startDate,
+                                @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                LocalDate endDate,
+                                String departureLoc, String arrivalLoc,
+                                String intermediaryName, String content
+                                ) {
+
+    // 리뷰 이미지 리스트 필드를 제외한 생성자
+    public ReviewGetResponse(String dogName, String volunteerNickname, String mainImage,
+                             LocalDate startDate, LocalDate endDate, String departureLoc, String arrivalLoc,
+                             String intermediaryName, String content) {
+        this(dogName, volunteerNickname, mainImage, null, startDate, endDate, departureLoc, arrivalLoc, intermediaryName, content);
+    }
+
+    // 리뷰 이미지 리스트 필드를 포함한 생성자
+    public static ReviewGetResponse of(ReviewGetResponse response, List<String> images) {
+        return new ReviewGetResponse(response.dogName, response.volunteerNickname, response.mainImage, images,
+                response.startDate, response.endDate, response.departureLoc, response.arrivalLoc, response.intermediaryName, response.content);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/review/entity/Review.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/entity/Review.java
@@ -2,7 +2,6 @@ package com.pawwithu.connectdog.domain.review.entity;
 
 import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
 import com.pawwithu.connectdog.domain.post.entity.Post;
-import com.pawwithu.connectdog.domain.post.entity.PostImage;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import jakarta.persistence.*;
 import lombok.*;
@@ -26,17 +25,16 @@ public class Review extends BaseTimeEntity {
     private Volunteer volunteer; // 이동봉사자 id
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "mainImage_id")
-    private PostImage mainImage; // 대표 이미지
+    private ReviewImage mainImage; // 대표 이미지
 
     @Builder
-    public Review(String content, Post post, Volunteer volunteer, PostImage mainImage) {
+    public Review(String content, Post post, Volunteer volunteer) {
         this.content = content;
         this.post = post;
         this.volunteer = volunteer;
-        this.mainImage = mainImage;
     }
 
-    public void updateMainImage(ReviewImage reviewImage) {
+    public void updateMainImage(ReviewImage mainImage) {
         this.mainImage = mainImage;
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/review/entity/ReviewImage.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/entity/ReviewImage.java
@@ -17,7 +17,7 @@ public class ReviewImage extends BaseTimeEntity {
     private String image; // 후기 사진
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "review_id", nullable = false)
-    private Review review; // 공고 id
+    private Review review; // 후기 id
 
     @Builder
     public ReviewImage(String image, Review review) {

--- a/src/main/java/com/pawwithu/connectdog/domain/review/repository/CustomReviewRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/repository/CustomReviewRepository.java
@@ -1,0 +1,12 @@
+package com.pawwithu.connectdog.domain.review.repository;
+
+import com.pawwithu.connectdog.domain.review.dto.response.ReviewGetResponse;
+
+import java.util.List;
+
+public interface CustomReviewRepository {
+    // 리뷰 상세 조회 (대표 이미지를 제외한 다른 이미지 포함 X)
+    ReviewGetResponse getOneReview(Long id, Long reviewId);
+    // 대표 이미지를 제외한 리뷰 이미지 조회
+    List<String> getOneReviewImages(Long reviewId);
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
@@ -36,7 +36,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
                 .fetch();
     }
 
-    // 후기 상세 조회 (대표 이미지를 제외한 다른 이미지 포함 X)
+    // 후기 단건 조회 (대표 이미지를 제외한 다른 이미지 포함 X)
     @Override
     public ReviewGetResponse getOneReview(Long id, Long reviewId) {
         return queryFactory
@@ -49,6 +49,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
                 .join(review.mainImage, reviewImage)
                 .join(review.post, post)
                 .join(review.post.dog, dog)
+                .join(review.post.intermediary, intermediary)
                 .where(review.id.eq(reviewId))
                 .fetchOne();
     }

--- a/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
@@ -1,0 +1,55 @@
+package com.pawwithu.connectdog.domain.review.repository.impl;
+
+import com.pawwithu.connectdog.domain.review.dto.response.ReviewGetResponse;
+import com.pawwithu.connectdog.domain.review.repository.CustomReviewRepository;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.pawwithu.connectdog.domain.intermediary.entity.QIntermediary.intermediary;
+import static com.pawwithu.connectdog.domain.post.entity.QPost.post;
+import static com.pawwithu.connectdog.domain.review.entity.QReview.review;
+import static com.pawwithu.connectdog.domain.review.entity.QReviewImage.reviewImage;
+import static com.pawwithu.connectdog.domain.dog.entity.QDog.dog;
+import static com.pawwithu.connectdog.domain.volunteer.entity.QVolunteer.volunteer;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class CustomReviewRepositoryImpl implements CustomReviewRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    // 대표 이미지를 제외한 리뷰 이미지 조회
+    @Override
+    public List<String> getOneReviewImages(Long reviewId) {
+        return queryFactory
+                .select(reviewImage.image)
+                .from(reviewImage)
+                .join(reviewImage.review, review)
+                .where(reviewImage.review.id.eq(reviewId)
+                        .and(review.mainImage.id.ne(reviewImage.id)))
+                .fetch();
+    }
+
+    // 후기 상세 조회 (대표 이미지를 제외한 다른 이미지 포함 X)
+    @Override
+    public ReviewGetResponse getOneReview(Long id, Long reviewId) {
+        return queryFactory
+                .select(Projections.constructor(ReviewGetResponse.class,
+                        dog.name, volunteer.nickname, reviewImage.image,
+                        post.startDate, post.endDate, post.departureLoc, post.arrivalLoc,
+                        intermediary.name, review.content))
+                .from(review)
+                .join(review.volunteer, volunteer)
+                .join(review.mainImage, reviewImage)
+                .join(review.post, post)
+                .join(review.post.dog, dog)
+                .where(review.id.eq(reviewId))
+                .fetchOne();
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/review/service/ReviewService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/service/ReviewService.java
@@ -4,8 +4,10 @@ import com.pawwithu.connectdog.common.s3.FileService;
 import com.pawwithu.connectdog.domain.post.entity.Post;
 import com.pawwithu.connectdog.domain.post.repository.PostRepository;
 import com.pawwithu.connectdog.domain.review.dto.request.ReviewCreateRequest;
+import com.pawwithu.connectdog.domain.review.dto.response.ReviewGetResponse;
 import com.pawwithu.connectdog.domain.review.entity.Review;
 import com.pawwithu.connectdog.domain.review.entity.ReviewImage;
+import com.pawwithu.connectdog.domain.review.repository.CustomReviewRepository;
 import com.pawwithu.connectdog.domain.review.repository.ReviewImageRepository;
 import com.pawwithu.connectdog.domain.review.repository.ReviewRepository;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
@@ -33,6 +35,7 @@ public class ReviewService {
     private final PostRepository postRepository;
     private final ReviewRepository reviewRepository;
     private final ReviewImageRepository reviewImageRepository;
+    private final CustomReviewRepository customReviewRepository;
 
     public void createReview(String email, Long postId, ReviewCreateRequest request, List<MultipartFile> fileList) {
 
@@ -58,5 +61,15 @@ public class ReviewService {
 
         // 후기 대표 이미지 업데이트
         review.updateMainImage(reviewImages.get(0));
+    }
+
+    public ReviewGetResponse getOneReview(String email, Long reviewId) {
+        Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
+        // 후기 조회 (대표 이미지 포함)
+        ReviewGetResponse oneReview = customReviewRepository.getOneReview(volunteer.getId(), reviewId);
+        // 후기 이미지 조회 (대표 이미지 제외)
+        List<String> oneReviewImages = customReviewRepository.getOneReviewImages(reviewId);
+        ReviewGetResponse response = ReviewGetResponse.of(oneReview, oneReviewImages);
+        return response;
     }
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/review/controller/ReviewControllerTest.java
@@ -2,7 +2,10 @@ package com.pawwithu.connectdog.domain.review.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.pawwithu.connectdog.domain.dog.entity.DogGender;
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
 import com.pawwithu.connectdog.domain.review.dto.request.ReviewCreateRequest;
+import com.pawwithu.connectdog.domain.review.dto.response.ReviewGetResponse;
 import com.pawwithu.connectdog.domain.review.service.ReviewService;
 import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
 import org.junit.jupiter.api.BeforeEach;
@@ -21,10 +24,15 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -66,4 +74,29 @@ class ReviewControllerTest {
         result.andExpect(status().isNoContent());
         verify(reviewService, times(1)).createReview(anyString(), anyLong(), any(), any());
     }
+
+    @Test
+    void 후기_단건_조회() throws Exception {
+        // given
+        Long reviewId = 1L;
+        LocalDate startDate = LocalDate.of(2023, 10, 2);
+        LocalDate endDate = LocalDate.of(2023, 11, 7);
+        List<String> images = new ArrayList<>();
+        images.add("image1");
+        images.add("image2");
+
+        ReviewGetResponse response = new ReviewGetResponse("겨울이", "호짱", "mainImage", images, startDate, endDate,
+                "서울시 노원구", "서울시 성북구", "이동봉사 중개", "후기 작성 테스트입니다.");
+
+        // when
+        given(reviewService.getOneReview(anyString(), anyLong())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/volunteers/reviews/{reviewId}", reviewId)
+        );
+
+        // then
+        result.andExpect(status().isOk());
+        verify(reviewService, times(1)).getOneReview(anyString(), anyLong());
+    }
+
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #45 

## 📝 작업 내용
- 이동봉사자 봉사 후기 등록 mainImage id 저장 안 되는 부분 수정
- 이동봉사자 봉사 후기 단건  조회 API 구현
- 이동봉사자 봉사 후기 단건  조회 Controller 테스트 코드 추가

## 💬 리뷰 요구 사항
- QueryDsl에서 쿼리 작성하는 부분과 mainImage를 포함한 응답 인스턴스와 mainImage를 제외한 imageList로 나눈 부분을 통일시켜서 구현하려고 했습니다! 쿼리 작성하는 부분에서 굉장히 편리함을 많이 느꼈습니다.
- Static import를 사용하는 방식으로 쿼리를 작성하게 되면, QClass 전체 이름을 반복해서 작성하지 않아도 되므로 코드가 더 간결하고, 자주 사용되는 QClass에 쉽게 접근할 수 있어서 효율적인 것 같습니다. join 부분은 innerjoin으로 관계 테이블의 값을 가져올 수 있어서 편리하다고 느낍니다!


