### PR TITLE
[Feature] 이동봉사 공고 필터 검색 API 정렬 조건 추가

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/post/dto/request/PostSearchRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/dto/request/PostSearchRequest.java
@@ -16,6 +16,7 @@ public record PostSearchRequest(@RequestParam(value = "postStatus", required = f
                                 LocalDate endDate,
                                 @RequestParam(value = "dogSize", required = false) DogSize dogSize,
                                 Boolean isKennel,
-                                String intermediaryName) {
+                                String intermediaryName,
+                                String orderCondition) {
     
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -16,8 +16,6 @@ spring:
 
   jpa:
     hibernate:
-      naming:
-        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
       ddl-auto: create
     properties:
       hibernate:

--- a/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
@@ -132,6 +132,7 @@ class PostControllerTest {
 //                        .param("dogSize", DogSize.SMALL.getKey())
                         .param("isKennel", "false")
                         .param("intermediaryName", "이동봉사 중개")
+                        .param("orderCondition", "마감순")
                         .param("page", "0")
                         .param("size", "2")
         );


### PR DESCRIPTION
## 💡 연관된 이슈
close #54 

## 📝 작업 내용
- 이동봉사 공고 필터 검색 API 최신순, 마감순 정렬 조건 추가
- Controller 테스트 코드 수정
- DB 네이밍 전략 수정

## 💬 리뷰 요구 사항
