### PR TITLE
[Feature] 이동봉사자 봉사 관리 - 승인 대기중, 진행중 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
@@ -1,6 +1,7 @@
 package com.pawwithu.connectdog.domain.application.controller;
 
 import com.pawwithu.connectdog.domain.application.dto.request.VolunteerApplyRequest;
+import com.pawwithu.connectdog.domain.application.dto.response.ApplicationWaitingResponse;
 import com.pawwithu.connectdog.domain.application.service.ApplicationService;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,13 +12,13 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Application", description = "Application API")
 @RestController
@@ -41,5 +42,18 @@ public class ApplicationController {
                                                @RequestBody @Valid VolunteerApplyRequest request) {
         applicationService.volunteerApply(loginUser.getUsername(), postId, request);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "봉사 관리 - 승인 대기중", description = "이동봉사 승인 대기중 목록을 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "이동봉사 승인 대기중 목록 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M1, 해당 이동봉사자를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping( "/volunteers/applications/waiting")
+    public ResponseEntity<List<ApplicationWaitingResponse>> getWaitingApplications(@AuthenticationPrincipal UserDetails loginUser,
+                                                                           Pageable pageable) {
+        List<ApplicationWaitingResponse> response = applicationService.getWaitingApplications(loginUser.getUsername(), pageable);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
@@ -1,6 +1,7 @@
 package com.pawwithu.connectdog.domain.application.controller;
 
 import com.pawwithu.connectdog.domain.application.dto.request.VolunteerApplyRequest;
+import com.pawwithu.connectdog.domain.application.dto.response.ApplicationProgressingResponse;
 import com.pawwithu.connectdog.domain.application.dto.response.ApplicationWaitingResponse;
 import com.pawwithu.connectdog.domain.application.service.ApplicationService;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
@@ -54,6 +55,19 @@ public class ApplicationController {
     public ResponseEntity<List<ApplicationWaitingResponse>> getWaitingApplications(@AuthenticationPrincipal UserDetails loginUser,
                                                                            Pageable pageable) {
         List<ApplicationWaitingResponse> response = applicationService.getWaitingApplications(loginUser.getUsername(), pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "봉사 관리 - 진행중", description = "이동봉사 진행중 목록을 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "이동봉사 진행중 목록 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M1, 해당 이동봉사자를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping( "/volunteers/applications/progressing")
+    public ResponseEntity<List<ApplicationProgressingResponse>> getProgressingApplications(@AuthenticationPrincipal UserDetails loginUser,
+                                                                                           Pageable pageable) {
+        List<ApplicationProgressingResponse> response = applicationService.getProgressingApplications(loginUser.getUsername(), pageable);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationProgressingResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationProgressingResponse.java
@@ -1,0 +1,14 @@
+package com.pawwithu.connectdog.domain.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+public record ApplicationProgressingResponse(String mainImage, String departureLoc, String arrivalLoc,
+                                             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                             LocalDate startDate,
+                                             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                             LocalDate endDate,
+                                             String intermediaryName,
+                                             Boolean isKennel) {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationWaitingResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationWaitingResponse.java
@@ -1,0 +1,15 @@
+package com.pawwithu.connectdog.domain.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+public record ApplicationWaitingResponse(String mainImage, String departureLoc, String arrivalLoc,
+                                         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                         LocalDate startDate,
+                                         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                         LocalDate endDate,
+                                         String intermediaryName,
+                                         Boolean isKennel,
+                                         Long applicationId) {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
@@ -1,5 +1,6 @@
 package com.pawwithu.connectdog.domain.application.repository;
 
+import com.pawwithu.connectdog.domain.application.dto.response.ApplicationProgressingResponse;
 import com.pawwithu.connectdog.domain.application.dto.response.ApplicationWaitingResponse;
 import org.springframework.data.domain.Pageable;
 
@@ -8,5 +9,5 @@ import java.util.List;
 public interface CustomApplicationRepository {
 
     List<ApplicationWaitingResponse> getWaitingApplications(Long volunteerId, Pageable pageable);
-
+    List<ApplicationProgressingResponse> getProgressingApplications(Long volunteerId, Pageable pageable);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
@@ -1,0 +1,12 @@
+package com.pawwithu.connectdog.domain.application.repository;
+
+import com.pawwithu.connectdog.domain.application.dto.response.ApplicationWaitingResponse;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+public interface CustomApplicationRepository {
+
+    List<ApplicationWaitingResponse> getWaitingApplications(Long volunteerId, Pageable pageable);
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.pawwithu.connectdog.domain.application.repository.impl;
 
+import com.pawwithu.connectdog.domain.application.dto.response.ApplicationProgressingResponse;
 import com.pawwithu.connectdog.domain.application.dto.response.ApplicationWaitingResponse;
 import com.pawwithu.connectdog.domain.application.entity.ApplicationStatus;
 import com.pawwithu.connectdog.domain.application.repository.CustomApplicationRepository;
@@ -35,6 +36,24 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
                 .join(application.post.intermediary, intermediary)
                 .join(application.post.mainImage, postImage)
                 .where(application.status.eq(ApplicationStatus.WAITING)
+                        .and(application.volunteer.id.eq(volunteerId)))
+                .orderBy(application.createdDate.desc())
+                .offset(pageable.getOffset())   // 페이지 번호
+                .limit(pageable.getPageSize())  // 페이지 사이즈
+                .fetch();
+    }
+
+    @Override
+    public List<ApplicationProgressingResponse> getProgressingApplications(Long volunteerId, Pageable pageable) {
+        return queryFactory
+                .select(Projections.constructor(ApplicationProgressingResponse.class,
+                        postImage.image, post.departureLoc, post.arrivalLoc, post.startDate, post.endDate,
+                        intermediary.name, post.isKennel))
+                .from(application)
+                .join(application.post, post)
+                .join(application.post.intermediary, intermediary)
+                .join(application.post.mainImage, postImage)
+                .where(application.status.eq(ApplicationStatus.PROGRESSING)
                         .and(application.volunteer.id.eq(volunteerId)))
                 .orderBy(application.createdDate.desc())
                 .offset(pageable.getOffset())   // 페이지 번호

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -1,0 +1,44 @@
+package com.pawwithu.connectdog.domain.application.repository.impl;
+
+import com.pawwithu.connectdog.domain.application.dto.response.ApplicationWaitingResponse;
+import com.pawwithu.connectdog.domain.application.entity.ApplicationStatus;
+import com.pawwithu.connectdog.domain.application.repository.CustomApplicationRepository;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.pawwithu.connectdog.domain.application.entity.QApplication.application;
+import static com.pawwithu.connectdog.domain.intermediary.entity.QIntermediary.intermediary;
+import static com.pawwithu.connectdog.domain.post.entity.QPost.post;
+import static com.pawwithu.connectdog.domain.post.entity.QPostImage.postImage;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class CustomApplicationRepositoryImpl implements CustomApplicationRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<ApplicationWaitingResponse> getWaitingApplications(Long volunteerId, Pageable pageable) {
+        return queryFactory
+                .select(Projections.constructor(ApplicationWaitingResponse.class,
+                        postImage.image, post.departureLoc, post.arrivalLoc, post.startDate, post.endDate,
+                        intermediary.name, post.isKennel, application.id))
+                .from(application)
+                .join(application.post, post)
+                .join(application.post.intermediary, intermediary)
+                .join(application.post.mainImage, postImage)
+                .where(application.status.eq(ApplicationStatus.WAITING)
+                        .and(application.volunteer.id.eq(volunteerId)))
+                .orderBy(application.createdDate.desc())
+                .offset(pageable.getOffset())   // 페이지 번호
+                .limit(pageable.getPageSize())  // 페이지 사이즈
+                .fetch();
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
@@ -1,20 +1,24 @@
 package com.pawwithu.connectdog.domain.application.service;
 
 import com.pawwithu.connectdog.domain.application.dto.request.VolunteerApplyRequest;
+import com.pawwithu.connectdog.domain.application.dto.response.ApplicationWaitingResponse;
 import com.pawwithu.connectdog.domain.application.entity.Application;
 import com.pawwithu.connectdog.domain.application.repository.ApplicationRepository;
+import com.pawwithu.connectdog.domain.application.repository.CustomApplicationRepository;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.post.entity.Post;
 import com.pawwithu.connectdog.domain.post.entity.PostStatus;
 import com.pawwithu.connectdog.domain.post.repository.PostRepository;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import com.pawwithu.connectdog.domain.volunteer.repository.VolunteerRepository;
-import com.pawwithu.connectdog.error.ErrorCode;
 import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static com.pawwithu.connectdog.error.ErrorCode.*;
 
@@ -27,6 +31,7 @@ public class ApplicationService {
     private final VolunteerRepository volunteerRepository;
     private final PostRepository postRepository;
     private final ApplicationRepository applicationRepository;
+    private final CustomApplicationRepository customApplicationRepository;
 
     public void volunteerApply(String email, Long postId, VolunteerApplyRequest request) {
         // 이동봉사자
@@ -47,5 +52,12 @@ public class ApplicationService {
 
         // 공고 상태 승인 대기 중으로 변경
         post.updateStatus(PostStatus.WAITING);
+    }
+
+    public List<ApplicationWaitingResponse> getWaitingApplications(String email, Pageable pageable) {
+        // 이동봉사자
+        Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
+        List<ApplicationWaitingResponse> waitingApplications = customApplicationRepository.getWaitingApplications(volunteer.getId(), pageable);
+        return waitingApplications;
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
@@ -1,6 +1,7 @@
 package com.pawwithu.connectdog.domain.application.service;
 
 import com.pawwithu.connectdog.domain.application.dto.request.VolunteerApplyRequest;
+import com.pawwithu.connectdog.domain.application.dto.response.ApplicationProgressingResponse;
 import com.pawwithu.connectdog.domain.application.dto.response.ApplicationWaitingResponse;
 import com.pawwithu.connectdog.domain.application.entity.Application;
 import com.pawwithu.connectdog.domain.application.repository.ApplicationRepository;
@@ -59,5 +60,12 @@ public class ApplicationService {
         Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
         List<ApplicationWaitingResponse> waitingApplications = customApplicationRepository.getWaitingApplications(volunteer.getId(), pageable);
         return waitingApplications;
+    }
+
+    public List<ApplicationProgressingResponse> getProgressingApplications(String email, Pageable pageable) {
+        // 이동봉사자
+        Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
+        List<ApplicationProgressingResponse> progressingApplications = customApplicationRepository.getProgressingApplications(volunteer.getId(), pageable);
+        return progressingApplications;
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
@@ -34,7 +34,6 @@ import static com.pawwithu.connectdog.domain.post.entity.QPostImage.postImage;
 public class CustomPostRepositoryImpl implements CustomPostRepository {
 
     private final JPAQueryFactory queryFactory;
-    private final BookmarkRepository bookmarkRepository;
 
     // 홈 화면 공고 5개 조회
     @Override

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,0 +1,38 @@
+-- INSERT INTERMEDIARY
+INSERT INTO intermediary (id, email, password, name, url, auth_image, profile_image, intro, contact, role, is_option_agr, notification, created_date, modified_date) VALUES (1, 'abc1@naver.com', '{bcrypt}$2a$10$Llg2MwZS/oOv/2/ozaice.49CU35kK6W9kYEb.oqyTy6vmh7E4yv2', '한호정', 'https://connectdog.site', 'authImageUrl', 'profileImageUrl', '안녕하세요.', '인스타그램: @hoxjeong', 'AUTH_INTERMEDIARY', false, false, now(), now());
+-- INSERT VOLUNTEER
+INSERT INTO volunteer (id, email, password, nickname, profile_image_num, name, phone, role, is_option_agr, notification, created_date, modified_date) VALUES (1, 'abc@naver.com', '{bcrypt}$2a$10$VieltvcRaI/rJnaRHuRPju9rqM9BvmKRkmn./oOninx7fOGT/q2De', '봉사자하노정', 1, '한호정', '01022223333', 'AUTH_VOLUNTEER', false, false, now(), now());
+-- INSERT DOG
+INSERT INTO dog (id, name, size, gender, weight, specifics, created_date, modified_date) VALUES (1, '포포', 0, 1, 4.6, '밥을 잘 먹음', now(), now());
+INSERT INTO dog (id, name, size, gender, weight, specifics, created_date, modified_date) VALUES (2, '남2포포', 1, 0, 4.6, '밥을 잘 먹음', now(), now());
+INSERT INTO dog (id, name, size, gender, weight, specifics, created_date, modified_date) VALUES (3, '여3포포', 2, 1, 4.6, '밥을 잘 먹음', now(), now());
+INSERT INTO dog (id, name, size, gender, weight, specifics, created_date, modified_date) VALUES (4, '여4포포', 2, 1, 4.6, '밥을 잘 먹음', now(), now());
+INSERT INTO dog (id, name, size, gender, weight, specifics, created_date, modified_date) VALUES (5, '남5포포', 1, 0, 4.6, '밥을 잘 먹음', now(), now());
+-- INSERT POST
+INSERT INTO post (id, status, departure_loc, arrival_loc, start_date, end_date, pick_up_time, is_kennel, content, intermediary_id, dog_id, created_date, modified_date) VALUES (1, 0, '서울시 성북구', '경기 고양시', '2023-11-13', '2023-11-25', '13:00', false, '이동봉사 공고입니다.', 1, 1, now(), now());
+INSERT INTO post (id, status, departure_loc, arrival_loc, start_date, end_date, pick_up_time, is_kennel, content, intermediary_id, dog_id, created_date, modified_date) VALUES (2, 0, '서울시 성북구', '경기 고양시', '2023-11-13', '2023-11-25', '13:00', false, '이동봉사 공고입니다.', 1, 2, now(), now());
+INSERT INTO post (id, status, departure_loc, arrival_loc, start_date, end_date, pick_up_time, is_kennel, content, intermediary_id, dog_id, created_date, modified_date) VALUES (3, 1, '서울시 성북구', '경기 고양시', '2023-11-13', '2023-11-25', '13:00', false, '이동봉사 공고입니다.', 1, 3, now(), now());
+INSERT INTO post (id, status, departure_loc, arrival_loc, start_date, end_date, pick_up_time, is_kennel, content, intermediary_id, dog_id, created_date, modified_date) VALUES (4, 2, '서울시 성북구', '경기 고양시', '2023-11-13', '2023-11-25', '13:00', false, '이동봉사 공고입니다.', 1, 4, now(), now());
+INSERT INTO post (id, status, departure_loc, arrival_loc, start_date, end_date, pick_up_time, is_kennel, content, intermediary_id, dog_id, created_date, modified_date) VALUES (5, 3, '서울시 성북구', '경기 고양시', '2023-11-13', '2023-11-25', '13:00', false, '이동봉사 공고입니다.', 1, 5, now(), now());
+-- INSERT POST_IMAGE
+INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (1, 'image1', 1, now(), now());
+INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (2, 'image2', 1, now(), now());
+INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (3, 'image3', 1, now(), now());
+INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (4, 'image1', 2, now(), now());
+INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (5, 'image2', 2, now(), now());
+INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (6, 'image1', 3, now(), now());
+INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (7, 'image2', 3, now(), now());
+INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (8, 'image1', 4, now(), now());
+INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (9, 'image2', 4, now(), now());
+INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (10, 'image1', 5, now(), now());
+INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (11, 'image2', 5, now(), now());
+-- UPDATE POST MAIN IMAGE
+UPDATE post SET main_image_id = 1 WHERE id = 1;
+UPDATE post SET main_image_id = 4 WHERE id = 2;
+UPDATE post SET main_image_id = 6 WHERE id = 3;
+UPDATE post SET main_image_id = 8 WHERE id = 4;
+UPDATE post SET main_image_id = 10 WHERE id = 5;
+-- INSERT APPLICATION
+INSERT INTO application (id, status, volunteer_name, phone, transportation, content, post_id, intermediary_id, volunteer_id, created_date, modified_date) VALUES (1, 0, '한호정', '01022223333', 'BMW', '이동봉사 신청합니다!', 3, 1, 1,now(), now());
+INSERT INTO application (id, status, volunteer_name, phone, transportation, content, post_id, intermediary_id, volunteer_id, created_date, modified_date) VALUES (2, 1, '한호정', '01022223333', 'BMW', '이동봉사 신청합니다!', 4, 1, 1,now(), now());
+INSERT INTO application (id, status, volunteer_name, phone, transportation, content, post_id, intermediary_id, volunteer_id, created_date, modified_date) VALUES (3, 2, '한호정', '01022223333', 'BMW', '이동봉사 신청합니다!', 5, 1, 1,now(), now());

--- a/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
@@ -2,7 +2,9 @@ package com.pawwithu.connectdog.domain.application.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pawwithu.connectdog.domain.application.dto.request.VolunteerApplyRequest;
+import com.pawwithu.connectdog.domain.application.dto.response.ApplicationWaitingResponse;
 import com.pawwithu.connectdog.domain.application.service.ApplicationService;
+import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
 import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -17,9 +19,15 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -59,5 +67,27 @@ class ApplicationControllerTest {
         //then
         result.andExpect(status().isNoContent());
         verify(applicationService, times(1)).volunteerApply(anyString(), anyLong(), any());
+    }
+
+    @Test
+    void 이동봉사_승인_대기중_목록_조회() throws Exception {
+        //given
+        List<ApplicationWaitingResponse> response = new ArrayList<>();
+        LocalDate startDate = LocalDate.of(2023, 10, 2);
+        LocalDate endDate = LocalDate.of(2023, 11, 7);
+        response.add(new ApplicationWaitingResponse("image1", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "이동봉사 중개", true, 1L));
+        response.add(new ApplicationWaitingResponse("image2", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "이동봉사 중개", false, 2L));
+
+        //when
+        given(applicationService.getWaitingApplications(anyString(), any())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/volunteers/applications/waiting")
+        );
+
+        //then
+        result.andExpect(status().isOk());
+        verify(applicationService, times(1)).getWaitingApplications(anyString(), any());
     }
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
@@ -2,9 +2,9 @@ package com.pawwithu.connectdog.domain.application.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pawwithu.connectdog.domain.application.dto.request.VolunteerApplyRequest;
+import com.pawwithu.connectdog.domain.application.dto.response.ApplicationProgressingResponse;
 import com.pawwithu.connectdog.domain.application.dto.response.ApplicationWaitingResponse;
 import com.pawwithu.connectdog.domain.application.service.ApplicationService;
-import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
 import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -89,5 +89,27 @@ class ApplicationControllerTest {
         //then
         result.andExpect(status().isOk());
         verify(applicationService, times(1)).getWaitingApplications(anyString(), any());
+    }
+
+    @Test
+    void 이동봉사_진행중_목록_조회() throws Exception {
+        //given
+        List<ApplicationProgressingResponse> response = new ArrayList<>();
+        LocalDate startDate = LocalDate.of(2023, 10, 2);
+        LocalDate endDate = LocalDate.of(2023, 11, 7);
+        response.add(new ApplicationProgressingResponse("image1", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "이동봉사 중개", true));
+        response.add(new ApplicationProgressingResponse("image2", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "이동봉사 중개", false));
+
+        //when
+        given(applicationService.getProgressingApplications(anyString(), any())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/volunteers/applications/progressing")
+        );
+
+        //then
+        result.andExpect(status().isOk());
+        verify(applicationService, times(1)).getProgressingApplications(anyString(), any());
     }
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #56 

## 📝 작업 내용
- 이동봉사자 승인 대기중 목록 조회 API 구현
- 이동봉사자 승인 대기중 목록 조회 Controller 테스트 코드 추가
- 이동봉사자 진행중 목록 조회 API 구현
- 이동봉사자 진행중 목록 조회 Controller 테스트 코드 추가
- 더미 데이터 추가

## 💬 리뷰 요구 사항
- 승인 대기중과 진행중인 신청 공고 목록을 조회하는 로직이 비슷해서 묶어서 PR 합니다!
- 더미 데이터를 추가해서 현재 postman에 있는 아이디 비밀번호로 로그인이 가능합니다! 다른 테이블의 값들도 추가했는데 필요한 값들이 있다면 알려주세요~
- 신청 관리 -> 봉사 관리로 변경되었는데 uri 관련해서 고민이 있습니다! 승인 대기중, 진행중, 봉사 완료의 uri를 /volunteers/applications으로 시작하는 게 괜찮을까요?