### PR TITLE
[Feature] 이동봉사 신청 취소 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
@@ -79,8 +79,9 @@ public class ApplicationController {
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @GetMapping( "/volunteers/applications/{applicationId}")
-    public ResponseEntity<ApplicationGetOneResponse> getOneApplication(@PathVariable Long applicationId) {
-        ApplicationGetOneResponse response = applicationService.getOneApplication(applicationId);
+    public ResponseEntity<ApplicationGetOneResponse> getOneApplication(@AuthenticationPrincipal UserDetails loginUser,
+                                                                       @PathVariable Long applicationId) {
+        ApplicationGetOneResponse response = applicationService.getOneApplication(loginUser.getUsername(), applicationId);
         return ResponseEntity.ok(response);
     }
 
@@ -91,8 +92,9 @@ public class ApplicationController {
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @DeleteMapping( "/volunteers/applications/{applicationId}")
-    public ResponseEntity<Void> deleteApplication(@PathVariable Long applicationId) {
-        applicationService.deleteApplication(applicationId);
+    public ResponseEntity<Void> deleteApplication(@AuthenticationPrincipal UserDetails loginUser,
+                                                  @PathVariable Long applicationId) {
+        applicationService.deleteApplication(loginUser.getUsername(), applicationId);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
@@ -79,10 +79,21 @@ public class ApplicationController {
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @GetMapping( "/volunteers/applications/{applicationId}")
-    public ResponseEntity<ApplicationGetOneResponse> getOneApplication(@AuthenticationPrincipal UserDetails loginUser,
-                                                                       @PathVariable Long applicationId) {
-        ApplicationGetOneResponse response = applicationService.getOneApplication(loginUser.getUsername(), applicationId);
+    public ResponseEntity<ApplicationGetOneResponse> getOneApplication(@PathVariable Long applicationId) {
+        ApplicationGetOneResponse response = applicationService.getOneApplication(applicationId);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "봉사 관리 - 승인 대기중 - 내 신청 내역 - 봉사 신청 취소", description = "내 신청 내역에서 봉사 신청을 취소합니다.",
+            responses = {@ApiResponse(responseCode = "204", description = "봉사 신청 취소 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M1, 해당 이동봉사자를 찾을 수 없습니다. \t\n AP2, 해당 신청 내역을 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @DeleteMapping( "/volunteers/applications/{applicationId}")
+    public ResponseEntity<Void> deleteApplication(@PathVariable Long applicationId) {
+        applicationService.deleteApplication(applicationId);
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/ApplicationRepository.java
@@ -3,7 +3,10 @@ package com.pawwithu.connectdog.domain.application.repository;
 import com.pawwithu.connectdog.domain.application.entity.Application;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ApplicationRepository extends JpaRepository<Application, Long> {
 
     Boolean existsByPostId(Long postId);
+    Optional<Application> findByIdAndVolunteerId(Long id, Long volunteerId);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
@@ -12,5 +12,5 @@ public interface CustomApplicationRepository {
 
     List<ApplicationWaitingResponse> getWaitingApplications(Long volunteerId, Pageable pageable);
     List<ApplicationProgressingResponse> getProgressingApplications(Long volunteerId, Pageable pageable);
-    Optional<Application> findByIdWithPost(Long applicationId);
+    Optional<Application> findByIdAndVolunteerIdWithPost(Long applicationId, Long volunteerId);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
@@ -2,12 +2,15 @@ package com.pawwithu.connectdog.domain.application.repository;
 
 import com.pawwithu.connectdog.domain.application.dto.response.ApplicationProgressingResponse;
 import com.pawwithu.connectdog.domain.application.dto.response.ApplicationWaitingResponse;
+import com.pawwithu.connectdog.domain.application.entity.Application;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CustomApplicationRepository {
 
     List<ApplicationWaitingResponse> getWaitingApplications(Long volunteerId, Pageable pageable);
     List<ApplicationProgressingResponse> getProgressingApplications(Long volunteerId, Pageable pageable);
+    Optional<Application> findByIdWithPost(Long applicationId);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -2,6 +2,7 @@ package com.pawwithu.connectdog.domain.application.repository.impl;
 
 import com.pawwithu.connectdog.domain.application.dto.response.ApplicationProgressingResponse;
 import com.pawwithu.connectdog.domain.application.dto.response.ApplicationWaitingResponse;
+import com.pawwithu.connectdog.domain.application.entity.Application;
 import com.pawwithu.connectdog.domain.application.entity.ApplicationStatus;
 import com.pawwithu.connectdog.domain.application.repository.CustomApplicationRepository;
 import com.querydsl.core.types.Projections;
@@ -12,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import static com.pawwithu.connectdog.domain.application.entity.QApplication.application;
 import static com.pawwithu.connectdog.domain.intermediary.entity.QIntermediary.intermediary;
@@ -59,5 +61,15 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
                 .offset(pageable.getOffset())   // 페이지 번호
                 .limit(pageable.getPageSize())  // 페이지 사이즈
                 .fetch();
+    }
+
+    @Override
+    public Optional<Application> findByIdWithPost(Long applicationId) {
+        return Optional.ofNullable(queryFactory
+                .select(application)
+                .from(application)
+                .join(application.post, post).fetchJoin()
+                .where(application.id.eq(applicationId))
+                .fetchOne());
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -64,12 +64,13 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
     }
 
     @Override
-    public Optional<Application> findByIdWithPost(Long applicationId) {
+    public Optional<Application> findByIdAndVolunteerIdWithPost(Long applicationId, Long volunteerId) {
         return Optional.ofNullable(queryFactory
                 .select(application)
                 .from(application)
                 .join(application.post, post).fetchJoin()
-                .where(application.id.eq(applicationId))
+                .where(application.id.eq(applicationId)
+                        .and(application.volunteer.id.eq(volunteerId)))
                 .fetchOne());
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
@@ -73,16 +73,20 @@ public class ApplicationService {
     }
 
     @Transactional(readOnly = true)
-    public ApplicationGetOneResponse getOneApplication(Long applicationId) {
+    public ApplicationGetOneResponse getOneApplication(String email, Long applicationId) {
+        // 이동봉사자
+        Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
         // 신청 내역
-        Application application = applicationRepository.findById(applicationId).orElseThrow(() -> new BadRequestException(APPLICATION_NOT_FOUND));
+        Application application = applicationRepository.findByIdAndVolunteerId(applicationId, volunteer.getId()).orElseThrow(() -> new BadRequestException(APPLICATION_NOT_FOUND));
         ApplicationGetOneResponse oneApplication = ApplicationGetOneResponse.from(application);
         return oneApplication;
     }
 
-    public void deleteApplication(Long applicationId) {
+    public void deleteApplication(String email, Long applicationId) {
+        // 이동봉사자
+        Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
         // 신청 내역 + post
-        Application application = customApplicationRepository.findByIdWithPost(applicationId).orElseThrow(() -> new BadRequestException(APPLICATION_NOT_FOUND));
+        Application application = customApplicationRepository.findByIdAndVolunteerIdWithPost(applicationId, volunteer.getId()).orElseThrow(() -> new BadRequestException(APPLICATION_NOT_FOUND));
         applicationRepository.delete(application);
         // 신청 취소 시: 공고 승인 대기중 -> 모집중
         Post post = application.getPost();

--- a/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
@@ -28,8 +28,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -121,13 +120,28 @@ class ApplicationControllerTest {
         Long applicationId = 1L;
 
         //when
-        given(applicationService.getOneApplication(anyString(), anyLong())).willReturn(response);
+        given(applicationService.getOneApplication(anyLong())).willReturn(response);
         ResultActions result = mockMvc.perform(
                 get("/volunteers/applications/{applicationId}", applicationId)
         );
 
         //then
         result.andExpect(status().isOk());
-        verify(applicationService, times(1)).getOneApplication(anyString(), anyLong());
+        verify(applicationService, times(1)).getOneApplication(anyLong());
+    }
+
+    @Test
+    void 이동봉사_신청_취소() throws Exception {
+        //given
+        Long applicationId = 1L;
+
+        //when
+        ResultActions result = mockMvc.perform(
+                delete("/volunteers/applications/{applicationId}", applicationId)
+        );
+
+        //then
+        result.andExpect(status().isNoContent());
+        verify(applicationService, times(1)).deleteApplication(anyLong());
     }
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
@@ -120,14 +120,14 @@ class ApplicationControllerTest {
         Long applicationId = 1L;
 
         //when
-        given(applicationService.getOneApplication(anyLong())).willReturn(response);
+        given(applicationService.getOneApplication(anyString(), anyLong())).willReturn(response);
         ResultActions result = mockMvc.perform(
                 get("/volunteers/applications/{applicationId}", applicationId)
         );
 
         //then
         result.andExpect(status().isOk());
-        verify(applicationService, times(1)).getOneApplication(anyLong());
+        verify(applicationService, times(1)).getOneApplication(anyString(), anyLong());
     }
 
     @Test
@@ -142,6 +142,6 @@ class ApplicationControllerTest {
 
         //then
         result.andExpect(status().isNoContent());
-        verify(applicationService, times(1)).deleteApplication(anyLong());
+        verify(applicationService, times(1)).deleteApplication(anyString(), anyLong());
     }
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #61 

## 📝 작업 내용
- 이동봉사 신청 취소 API 구현
- 이동봉사 신청 취소 Controller 테스트 코드 추가
PR 이후 커밋
- 이동봉사 신청 내역 단건 조회, 이동봉사 신청 취소 검증 로직 추가
- 이동봉사 신청 내역 단건 조회, 이동봉사 신청 취소 테스트 코드 추가

## 💬 리뷰 요구 사항
- application 불러오는 쿼리 1번 + post 불러오는 쿼리 1번
![image](https://github.com/PawWithU/ConnectDog-Server/assets/80199502/9082ec06-7f89-4b7e-b223-f40c8f659a6a)
- application + post 불러오는 쿼리 1번
![image](https://github.com/PawWithU/ConnectDog-Server/assets/80199502/a6edc904-e0a1-4476-af65-335e985586d8)

가져오는 데이터가 너무 많지 않고 동일하다면, 데이터베이스와 통신이 2번 이루어지는 것보다 1번 이루어지는 것이 낫다고 판단해서 첫 번째로 코드를 작성했습니다!

@AuthenticationPrincipal로 로그인한 사용자의 정보를 불러오고 이동봉사자를 찾는 메서드 첫 줄을 커밋할 때는 지웠습니다! 
앞의 이동봉사 단건 조회와 이번 작업인 이동봉사 신청 취소는 이동봉사자와 관련된 정보를 이용하지 않기 때문이었습니다.

하지만 고민이 되는 게 이동봉사자가 자신의 신청 내역을 지우는 게 맞는지에 대해 검증이 필요할까요? 지금은 해당 신청 id로 봉사 신청 취소를 누를 경우 해당 신청을 삭제하도록 만들었습니다.

쓰다 보니까 검증이 필요할 것 같다고 생각해서 추가했습니다! 신청 id와 이동봉사자 id로 application을 조회하도록 바꿨습니다. (리뷰하실 때 커밋 메시지에서 어떤 부분이 바뀌었는지 확인해 보시면 좋을 거 같아요)