### PR TITLE
[Feature] 이동봉사 중개 강아지 근황 등록 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/controller/DogStatusController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/controller/DogStatusController.java
@@ -30,11 +30,11 @@ public class DogStatusController {
 
     private final DogStatusService dogStatusService;
 
-    @Operation(summary = "근황 등록", description = "근황를 등록합니다.",
+    @Operation(summary = "근황 등록", description = "근황을 등록합니다.",
             security = { @SecurityRequirement(name = "bearer-key") },
             responses = {@ApiResponse(responseCode = "204", description = "근황 등록 성공")
                     , @ApiResponse(responseCode = "400"
-                    , description = "V1, 내용은 20~300자로 입력해 주세요. \t\n F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n " +
+                    , description = "V1, 근황 내용은 필수 입력 값입니다. \t\n V1, 내용은 20~300자로 입력해 주세요. \t\n F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n " +
                     "M2, 해당 이동봉사 중개를 찾을 수 없습니다. \t\n P2, 해당 공고를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })

--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/controller/DogStatusController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/controller/DogStatusController.java
@@ -1,0 +1,48 @@
+package com.pawwithu.connectdog.domain.dogStatus.controller;
+
+import com.pawwithu.connectdog.domain.dogStatus.dto.request.DogStatusCreateRequest;
+import com.pawwithu.connectdog.domain.dogStatus.service.DogStatusService;
+import com.pawwithu.connectdog.error.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Tag(name = "DogStatus", description = "DogStatus API")
+@RestController
+@RequiredArgsConstructor
+public class DogStatusController {
+
+    private final DogStatusService dogStatusService;
+
+    @Operation(summary = "근황 등록", description = "근황를 등록합니다.",
+            security = { @SecurityRequirement(name = "bearer-key") },
+            responses = {@ApiResponse(responseCode = "204", description = "근황 등록 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "V1, 내용은 20~300자로 입력해 주세요. \t\n F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n " +
+                    "M2, 해당 이동봉사 중개를 찾을 수 없습니다. \t\n P2, 해당 공고를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @PostMapping(value = "/intermediaries/posts/{postId}/dogStatus", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
+    public ResponseEntity<Void> createReview(@AuthenticationPrincipal UserDetails loginUser, @PathVariable("postId") Long postId,
+                                             @RequestPart @Valid DogStatusCreateRequest request,
+                                             @RequestPart(name = "files", required = false) List<MultipartFile> files) {
+        dogStatusService.createDogStatus(loginUser.getUsername(), postId, request, files);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/dto/request/DogStatusCreateRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/dto/request/DogStatusCreateRequest.java
@@ -1,0 +1,20 @@
+package com.pawwithu.connectdog.domain.dogStatus.dto.request;
+
+import com.pawwithu.connectdog.domain.dogStatus.entity.DogStatus;
+import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
+import com.pawwithu.connectdog.domain.post.entity.Post;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record DogStatusCreateRequest(@NotBlank(message = "근황 내용은 필수 입력 값입니다.")
+                                     @Size(min=20, max=300, message = "내용은 20~300자로 입력해 주세요.")
+                                     String content) {
+
+    public static DogStatus dogStatusToEntity(DogStatusCreateRequest request, Intermediary intermediary, Post post) {
+        return DogStatus.builder()
+                .content(request.content)
+                .intermediary(intermediary)
+                .post(post)
+                .build();
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/entity/DogStatus.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/entity/DogStatus.java
@@ -4,10 +4,7 @@ import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.post.entity.Post;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,4 +23,19 @@ public class DogStatus extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "intermediary_id", nullable = false)
     private Intermediary intermediary;  // 이동봉사 중개 id
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mainImage_id")
+    private DogStatusImage mainImage; // 대표 이미지
+
+    @Builder
+    public DogStatus(String content, Post post, Intermediary intermediary) {
+        this.content = content;
+        this.post = post;
+        this.intermediary = intermediary;
+    }
+
+    public void updateMainImage(DogStatusImage mainImage) {
+        this.mainImage = mainImage;
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/entity/DogStatusImage.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/entity/DogStatusImage.java
@@ -2,10 +2,7 @@ package com.pawwithu.connectdog.domain.dogStatus.entity;
 
 import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -21,4 +18,10 @@ public class DogStatusImage extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "dogStatus_id", nullable = false)
     private DogStatus dogStatus;  // 근황 id
+
+    @Builder
+    public DogStatusImage(String image, DogStatus dogStatus) {
+        this.image = image;
+        this.dogStatus = dogStatus;
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/repository/DogStatusImageRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/repository/DogStatusImageRepository.java
@@ -1,0 +1,7 @@
+package com.pawwithu.connectdog.domain.dogStatus.repository;
+
+import com.pawwithu.connectdog.domain.dogStatus.entity.DogStatusImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DogStatusImageRepository extends JpaRepository<DogStatusImage, Long> {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/repository/DogStatusRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/repository/DogStatusRepository.java
@@ -1,0 +1,7 @@
+package com.pawwithu.connectdog.domain.dogStatus.repository;
+
+import com.pawwithu.connectdog.domain.dogStatus.entity.DogStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DogStatusRepository extends JpaRepository<DogStatus, Long> {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/service/DogStatusService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/service/DogStatusService.java
@@ -1,0 +1,62 @@
+package com.pawwithu.connectdog.domain.dogStatus.service;
+
+import com.pawwithu.connectdog.common.s3.FileService;
+import com.pawwithu.connectdog.domain.dogStatus.dto.request.DogStatusCreateRequest;
+import com.pawwithu.connectdog.domain.dogStatus.entity.DogStatus;
+import com.pawwithu.connectdog.domain.dogStatus.entity.DogStatusImage;
+import com.pawwithu.connectdog.domain.dogStatus.repository.DogStatusImageRepository;
+import com.pawwithu.connectdog.domain.dogStatus.repository.DogStatusRepository;
+import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
+import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
+import com.pawwithu.connectdog.domain.post.entity.Post;
+import com.pawwithu.connectdog.domain.post.repository.PostRepository;
+import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.pawwithu.connectdog.error.ErrorCode.*;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DogStatusService {
+
+    private final FileService fileService;
+    private final IntermediaryRepository intermediaryRepository;
+    private final PostRepository postRepository;
+    private final DogStatusRepository dogStatusRepository;
+    private final DogStatusImageRepository dogStatusImageRepository;
+
+    public void createDogStatus(String email, Long postId, DogStatusCreateRequest request, List<MultipartFile> fileList) {
+
+        // 파일이 존재하지 않을 경우
+        if (fileList.isEmpty())
+            throw new BadRequestException(FILE_NOT_FOUND);
+
+        Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new BadRequestException(POST_NOT_FOUND));
+
+        // 근황 저장 (대표 이미지 제외)
+        DogStatus dogStatus = DogStatusCreateRequest.dogStatusToEntity(request, intermediary, post);
+        DogStatus saveDogStatus = dogStatusRepository.save(dogStatus);
+
+        // 근황 이미지 저장
+        List<DogStatusImage> dogStatusImages = fileList.stream()
+                .map(f -> DogStatusImage.builder()
+                        .image(fileService.uploadFile(f, "intermediary/dogStatus"))
+                        .dogStatus(saveDogStatus)
+                        .build())
+                .collect(Collectors.toList());
+        dogStatusImageRepository.saveAll(dogStatusImages);
+
+        // 근황 대표 이미지 업데이트
+        dogStatus.updateMainImage(dogStatusImages.get(0));
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/controller/ReviewController.java
@@ -34,7 +34,7 @@ public class ReviewController {
             security = { @SecurityRequirement(name = "bearer-key") },
             responses = {@ApiResponse(responseCode = "204", description = "후기 등록 성공")
                     , @ApiResponse(responseCode = "400"
-                    , description = "V1, 내용은 20~300자로 입력해 주세요. \t\n F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n " +
+                    , description = "V1, 후기 내용은 필수 입력 값입니다. \t\n V1, 내용은 20~300자로 입력해 주세요. \t\n F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n " +
                     "M1, 해당 이동봉사자를 찾을 수 없습니다. \t\n P2, 해당 공고를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })

--- a/src/main/java/com/pawwithu/connectdog/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/controller/ReviewController.java
@@ -34,7 +34,8 @@ public class ReviewController {
             security = { @SecurityRequirement(name = "bearer-key") },
             responses = {@ApiResponse(responseCode = "204", description = "후기 등록 성공")
                     , @ApiResponse(responseCode = "400"
-                    , description = "V1, 내용은 20~300자로 입력해 주세요. \t\n F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n M2, 해당 이동봉사 중개를 찾을 수 없습니다."
+                    , description = "V1, 내용은 20~300자로 입력해 주세요. \t\n F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n " +
+                    "M1, 해당 이동봉사자를 찾을 수 없습니다. \t\n P2, 해당 공고를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PostMapping(value = "/volunteers/posts/{postId}/reviews", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})

--- a/src/main/java/com/pawwithu/connectdog/domain/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/dto/request/ReviewCreateRequest.java
@@ -12,10 +12,9 @@ public record ReviewCreateRequest(@NotBlank(message = "후기 내용은 필수 �
 
     public static Review reviewToEntity(ReviewCreateRequest request, Volunteer volunteer, Post post) {
         return Review.builder()
-                .content(request.content())
+                .content(request.content)
                 .volunteer(volunteer)
                 .post(post)
                 .build();
     }
-
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/dogStatus/controller/DogStatusControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/dogStatus/controller/DogStatusControllerTest.java
@@ -1,0 +1,71 @@
+package com.pawwithu.connectdog.domain.dogStatus.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.pawwithu.connectdog.domain.dogStatus.dto.request.DogStatusCreateRequest;
+import com.pawwithu.connectdog.domain.dogStatus.service.DogStatusService;
+import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+
+class DogStatusControllerTest {
+
+    @InjectMocks
+    private DogStatusController dogStatusController;
+    @Mock
+    private DogStatusService dogStatusService;
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(dogStatusController)
+                .setCustomArgumentResolvers(new TestUserArgumentResolver(), new PageableHandlerMethodArgumentResolver())
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+
+    @Test
+    void 근황_등록() throws Exception {
+        // given
+        Long postId = 1L;
+        DogStatusCreateRequest dogStatusCreateRequest = new DogStatusCreateRequest("강아지 근황 - 겨울이는 호짱님 덕분에 잘 지내고 있답니다 :)");
+
+        MockMultipartFile files = new MockMultipartFile("files", "image1.png", "multipart/form-data", "uploadFile".getBytes(StandardCharsets.UTF_8));
+        MockMultipartFile request = new MockMultipartFile("request", "", "application/json", objectMapper.registerModule(new JavaTimeModule()).writeValueAsString(dogStatusCreateRequest).getBytes(StandardCharsets.UTF_8));
+
+        // when
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders
+                .multipart(HttpMethod.POST, "/intermediaries/posts/{postId}/dogStatus", postId)
+                .file(request)
+                .file(files)
+                .accept(MediaType.APPLICATION_JSON)
+                .contentType(MediaType.MULTIPART_FORM_DATA));
+
+        // then
+        result.andExpect(status().isNoContent());
+        verify(dogStatusService, times(1)).createDogStatus(anyString(), anyLong(), any(), any());
+    }
+}

--- a/src/test/java/com/pawwithu/connectdog/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/review/controller/ReviewControllerTest.java
@@ -57,14 +57,14 @@ class ReviewControllerTest {
     void 후기_등록() throws Exception {
         // given
         Long postId = 1L;
-        ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest("이동봉사 리뷰입니다.");
+        ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest("이동봉사 리뷰 테스트 - 봄이는 귀엽고 예쁘고 차분하다!");
 
         MockMultipartFile files = new MockMultipartFile("files", "image1.png", "multipart/form-data", "uploadFile".getBytes(StandardCharsets.UTF_8));
         MockMultipartFile request = new MockMultipartFile("request", "", "application/json", objectMapper.registerModule(new JavaTimeModule()).writeValueAsString(reviewCreateRequest).getBytes(StandardCharsets.UTF_8));
 
         // when
         ResultActions result = mockMvc.perform(MockMvcRequestBuilders
-                .multipart(HttpMethod.POST, "/volunteers/reviews/{postId}", postId)
+                .multipart(HttpMethod.POST, "/volunteers/posts/{postId}/reviews", postId)
                 .file(request)
                 .file(files)
                 .accept(MediaType.APPLICATION_JSON)


### PR DESCRIPTION
## 💡 연관된 이슈
close #63 

## 📝 작업 내용
- DogStatus에 외래키 제약 조건을 가진 mainImage 필드 추가 후 1:1 연관 관계 설정 추가 (공고/리뷰와 동일)
- ReviewControllerTest 수정된 로직 반영 (후기 등록 시 uri 변경 & 후기 내용 validation 추가 건)
- 이동봉사 중개 강아지 근황 등록 API 구현
- 이동봉사 중개 강아지 근황 등록 Controller 테스트 코드 추가


## 💬 리뷰 요구 사항
후기와 동일한 로직입니다。
