### PR TITLE
[Feature] 이동봉사 중개 봉사관리 - 모집중, 모집 마감 공고 조회 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationProgressingResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationProgressingResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDate;
 
-public record ApplicationProgressingResponse(String mainImage, String departureLoc, String arrivalLoc,
+public record ApplicationProgressingResponse(Long postId, String mainImage, String departureLoc, String arrivalLoc,
                                              @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                              LocalDate startDate,
                                              @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")

--- a/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationWaitingResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationWaitingResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDate;
 
-public record ApplicationWaitingResponse(String mainImage, String departureLoc, String arrivalLoc,
+public record ApplicationWaitingResponse(Long postId, String mainImage, String departureLoc, String arrivalLoc,
                                          @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                          LocalDate startDate,
                                          @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -31,7 +31,7 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
     public List<ApplicationWaitingResponse> getWaitingApplications(Long volunteerId, Pageable pageable) {
         return queryFactory
                 .select(Projections.constructor(ApplicationWaitingResponse.class,
-                        postImage.image, post.departureLoc, post.arrivalLoc, post.startDate, post.endDate,
+                        post.id, postImage.image, post.departureLoc, post.arrivalLoc, post.startDate, post.endDate,
                         intermediary.name, post.isKennel, application.id))
                 .from(application)
                 .join(application.post, post)
@@ -49,7 +49,7 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
     public List<ApplicationProgressingResponse> getProgressingApplications(Long volunteerId, Pageable pageable) {
         return queryFactory
                 .select(Projections.constructor(ApplicationProgressingResponse.class,
-                        postImage.image, post.departureLoc, post.arrivalLoc, post.startDate, post.endDate,
+                        post.id, postImage.image, post.departureLoc, post.arrivalLoc, post.startDate, post.endDate,
                         intermediary.name, post.isKennel))
                 .from(application)
                 .join(application.post, post)

--- a/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
@@ -4,6 +4,7 @@ import com.pawwithu.connectdog.domain.post.dto.request.PostCreateRequest;
 import com.pawwithu.connectdog.domain.post.dto.request.PostSearchRequest;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetOneResponse;
+import com.pawwithu.connectdog.domain.post.dto.response.PostRecruitingGetResponse;
 import com.pawwithu.connectdog.domain.post.dto.response.PostSearchResponse;
 import com.pawwithu.connectdog.domain.post.service.PostService;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
@@ -78,5 +79,17 @@ public class PostController {
     public ResponseEntity<PostGetOneResponse> getOnePost(@AuthenticationPrincipal UserDetails loginUser, @PathVariable Long postId) {
         PostGetOneResponse onePost = postService.getOnePost(loginUser.getUsername(), postId);
         return ResponseEntity.ok(onePost);
+    }
+
+    @Operation(summary = "봉사 관리 - 모집중, 모집 마감", description = "이동봉사 모집중, 모집 마감 목록을 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "이동봉사 모집중, 모집 마감 목록 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping( "/intermediaries/posts/recruiting")
+    public ResponseEntity<List<PostRecruitingGetResponse>> getRecruitingPosts(@AuthenticationPrincipal UserDetails loginUser, Pageable pageable) {
+        List<PostRecruitingGetResponse> response = postService.getRecruitingPosts(loginUser.getUsername(), pageable);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostRecruitingGetResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostRecruitingGetResponse.java
@@ -1,0 +1,20 @@
+package com.pawwithu.connectdog.domain.post.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.pawwithu.connectdog.domain.post.entity.PostStatus;
+
+import java.time.LocalDate;
+
+public record PostRecruitingGetResponse(Long postId, String postStatus, String mainImage, String dogName, String departureLoc, String arrivalLoc,
+                                        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                     LocalDate startDate,
+                                        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                     LocalDate endDate,
+                                        String volunteerName) {
+
+    // 공고 이동봉사자 이름을 제외한 생성자
+    public PostRecruitingGetResponse(Long postId, PostStatus postStatus, String mainImage, String dogName, String departureLoc, String arrivalLoc,
+                                     LocalDate startDate, LocalDate endDate) {
+        this(postId, postStatus.getKey(), mainImage, dogName, departureLoc, arrivalLoc, startDate, endDate, null);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
@@ -3,6 +3,7 @@ package com.pawwithu.connectdog.domain.post.repository;
 import com.pawwithu.connectdog.domain.post.dto.request.PostSearchRequest;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetOneResponse;
+import com.pawwithu.connectdog.domain.post.dto.response.PostRecruitingGetResponse;
 import com.pawwithu.connectdog.domain.post.dto.response.PostSearchResponse;
 import org.springframework.data.domain.Pageable;
 
@@ -18,4 +19,5 @@ public interface CustomPostRepository {
     List<String> getOnePostImages(Long postId);
     // 공고 상세 조회 (대표 이미지를 제외한 다른 이미지 포함 X)
     PostGetOneResponse getOnePost(Long volunteerId, Long postId);
+    List<PostRecruitingGetResponse> getRecruitingPosts(Long intermediaryId, Pageable pageable);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
@@ -1,10 +1,10 @@
 package com.pawwithu.connectdog.domain.post.repository.impl;
 
-import com.pawwithu.connectdog.domain.bookmark.repository.BookmarkRepository;
 import com.pawwithu.connectdog.domain.dog.entity.DogSize;
 import com.pawwithu.connectdog.domain.post.dto.request.PostSearchRequest;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetOneResponse;
+import com.pawwithu.connectdog.domain.post.dto.response.PostRecruitingGetResponse;
 import com.pawwithu.connectdog.domain.post.dto.response.PostSearchResponse;
 import com.pawwithu.connectdog.domain.post.entity.PostStatus;
 import com.pawwithu.connectdog.domain.post.repository.CustomPostRepository;
@@ -20,7 +20,6 @@ import org.springframework.stereotype.Repository;
 import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.pawwithu.connectdog.domain.dog.entity.QDog.dog;
@@ -95,6 +94,23 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                 .join(post.dog, dog)
                 .where(post.id.eq(postId))
                 .fetchOne();
+    }
+
+    @Override
+    public List<PostRecruitingGetResponse> getRecruitingPosts(Long intermediaryId, Pageable pageable) {
+        return queryFactory
+                .select(Projections.constructor(PostRecruitingGetResponse.class,
+                        post.id, post.status, postImage.image, dog.name, post.departureLoc, post.arrivalLoc,
+                        post.startDate, post.endDate))
+                .from(post)
+                .join(post.mainImage, postImage)
+                .join(post.dog, dog)
+                .where(post.intermediary.id.eq(intermediaryId)
+                        .and(post.status.in(PostStatus.RECRUITING, PostStatus.EXPIRED)))
+                .orderBy(post.createdDate.desc())
+                .offset(pageable.getOffset())   // 페이지 번호
+                .limit(pageable.getPageSize())  // 페이지 사이즈
+                .fetch();
     }
 
     // 모든 필터 검색

--- a/src/main/java/com/pawwithu/connectdog/domain/post/service/PostService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/service/PostService.java
@@ -10,6 +10,7 @@ import com.pawwithu.connectdog.domain.post.dto.request.PostCreateRequest;
 import com.pawwithu.connectdog.domain.post.dto.request.PostSearchRequest;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetOneResponse;
+import com.pawwithu.connectdog.domain.post.dto.response.PostRecruitingGetResponse;
 import com.pawwithu.connectdog.domain.post.dto.response.PostSearchResponse;
 import com.pawwithu.connectdog.domain.post.entity.Post;
 import com.pawwithu.connectdog.domain.post.entity.PostImage;
@@ -98,5 +99,12 @@ public class PostService {
         Boolean isBookmark = bookmarkRepository.existsByVolunteerIdAndPostId(volunteer.getId(), postId);
         PostGetOneResponse response = PostGetOneResponse.of(onePost, onePostImages, isBookmark);
         return response;
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostRecruitingGetResponse> getRecruitingPosts(String email, Pageable pageable) {
+        Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
+        List<PostRecruitingGetResponse> recruitingPosts = customPostRepository.getRecruitingPosts(intermediary.getId(), pageable);
+        return recruitingPosts;
     }
 }

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -8,12 +8,14 @@ INSERT INTO dog (id, name, size, gender, weight, specifics, created_date, modifi
 INSERT INTO dog (id, name, size, gender, weight, specifics, created_date, modified_date) VALUES (3, '여3포포', 2, 1, 4.6, '밥을 잘 먹음', now(), now());
 INSERT INTO dog (id, name, size, gender, weight, specifics, created_date, modified_date) VALUES (4, '여4포포', 2, 1, 4.6, '밥을 잘 먹음', now(), now());
 INSERT INTO dog (id, name, size, gender, weight, specifics, created_date, modified_date) VALUES (5, '남5포포', 1, 0, 4.6, '밥을 잘 먹음', now(), now());
+INSERT INTO dog (id, name, size, gender, weight, specifics, created_date, modified_date) VALUES (6, '남6포포', 1, 0, 4.6, '밥을 잘 먹음', now(), now());
 -- INSERT POST
 INSERT INTO post (id, status, departure_loc, arrival_loc, start_date, end_date, pick_up_time, is_kennel, content, intermediary_id, dog_id, created_date, modified_date) VALUES (1, 0, '서울시 성북구', '경기 고양시', '2023-11-13', '2023-11-25', '13:00', false, '이동봉사 공고입니다.', 1, 1, now(), now());
 INSERT INTO post (id, status, departure_loc, arrival_loc, start_date, end_date, pick_up_time, is_kennel, content, intermediary_id, dog_id, created_date, modified_date) VALUES (2, 0, '서울시 성북구', '경기 고양시', '2023-11-13', '2023-11-25', '13:00', false, '이동봉사 공고입니다.', 1, 2, now(), now());
 INSERT INTO post (id, status, departure_loc, arrival_loc, start_date, end_date, pick_up_time, is_kennel, content, intermediary_id, dog_id, created_date, modified_date) VALUES (3, 1, '서울시 성북구', '경기 고양시', '2023-11-13', '2023-11-25', '13:00', false, '이동봉사 공고입니다.', 1, 3, now(), now());
 INSERT INTO post (id, status, departure_loc, arrival_loc, start_date, end_date, pick_up_time, is_kennel, content, intermediary_id, dog_id, created_date, modified_date) VALUES (4, 2, '서울시 성북구', '경기 고양시', '2023-11-13', '2023-11-25', '13:00', false, '이동봉사 공고입니다.', 1, 4, now(), now());
 INSERT INTO post (id, status, departure_loc, arrival_loc, start_date, end_date, pick_up_time, is_kennel, content, intermediary_id, dog_id, created_date, modified_date) VALUES (5, 3, '서울시 성북구', '경기 고양시', '2023-11-13', '2023-11-25', '13:00', false, '이동봉사 공고입니다.', 1, 5, now(), now());
+INSERT INTO post (id, status, departure_loc, arrival_loc, start_date, end_date, pick_up_time, is_kennel, content, intermediary_id, dog_id, created_date, modified_date) VALUES (6, 4, '서울시 성북구', '경기 고양시', '2023-11-13', '2023-11-25', '13:00', false, '이동봉사 공고입니다.', 1, 6, now(), now());
 -- INSERT POST_IMAGE
 INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (1, 'image1', 1, now(), now());
 INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (2, 'image2', 1, now(), now());
@@ -26,12 +28,15 @@ INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES 
 INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (9, 'image2', 4, now(), now());
 INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (10, 'image1', 5, now(), now());
 INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (11, 'image2', 5, now(), now());
+INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (12, 'image1', 6, now(), now());
+INSERT INTO post_image (id, image, post_id, created_date, modified_date) VALUES (13, 'image2', 6, now(), now());
 -- UPDATE POST MAIN IMAGE
 UPDATE post SET main_image_id = 1 WHERE id = 1;
 UPDATE post SET main_image_id = 4 WHERE id = 2;
 UPDATE post SET main_image_id = 6 WHERE id = 3;
 UPDATE post SET main_image_id = 8 WHERE id = 4;
 UPDATE post SET main_image_id = 10 WHERE id = 5;
+UPDATE post SET main_image_id = 12 WHERE id = 6;
 -- INSERT APPLICATION
 INSERT INTO application (id, status, volunteer_name, phone, transportation, content, post_id, intermediary_id, volunteer_id, created_date, modified_date) VALUES (1, 0, '한호정', '01022223333', 'BMW', '이동봉사 신청합니다!', 3, 1, 1,now(), now());
 INSERT INTO application (id, status, volunteer_name, phone, transportation, content, post_id, intermediary_id, volunteer_id, created_date, modified_date) VALUES (2, 1, '한호정', '01022223333', 'BMW', '이동봉사 신청합니다!', 4, 1, 1,now(), now());

--- a/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
@@ -75,9 +75,9 @@ class ApplicationControllerTest {
         List<ApplicationWaitingResponse> response = new ArrayList<>();
         LocalDate startDate = LocalDate.of(2023, 10, 2);
         LocalDate endDate = LocalDate.of(2023, 11, 7);
-        response.add(new ApplicationWaitingResponse("image1", "서울시 성북구", "서울시 중랑구",
+        response.add(new ApplicationWaitingResponse(1L, "image1", "서울시 성북구", "서울시 중랑구",
                 startDate, endDate, "이동봉사 중개", true, 1L));
-        response.add(new ApplicationWaitingResponse("image2", "서울시 성북구", "서울시 중랑구",
+        response.add(new ApplicationWaitingResponse(2L, "image2", "서울시 성북구", "서울시 중랑구",
                 startDate, endDate, "이동봉사 중개", false, 2L));
 
         //when
@@ -97,9 +97,9 @@ class ApplicationControllerTest {
         List<ApplicationProgressingResponse> response = new ArrayList<>();
         LocalDate startDate = LocalDate.of(2023, 10, 2);
         LocalDate endDate = LocalDate.of(2023, 11, 7);
-        response.add(new ApplicationProgressingResponse("image1", "서울시 성북구", "서울시 중랑구",
+        response.add(new ApplicationProgressingResponse(1L, "image1", "서울시 성북구", "서울시 중랑구",
                 startDate, endDate, "이동봉사 중개", true));
-        response.add(new ApplicationProgressingResponse("image2", "서울시 성북구", "서울시 중랑구",
+        response.add(new ApplicationProgressingResponse(2L, "image2", "서울시 성북구", "서울시 중랑구",
                 startDate, endDate, "이동봉사 중개", false));
 
         //when

--- a/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
@@ -5,7 +5,9 @@ import com.pawwithu.connectdog.domain.dog.entity.DogGender;
 import com.pawwithu.connectdog.domain.dog.entity.DogSize;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetOneResponse;
+import com.pawwithu.connectdog.domain.post.dto.response.PostRecruitingGetResponse;
 import com.pawwithu.connectdog.domain.post.dto.response.PostSearchResponse;
+import com.pawwithu.connectdog.domain.post.entity.PostStatus;
 import com.pawwithu.connectdog.domain.post.service.PostService;
 import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
 import org.junit.jupiter.api.BeforeEach;
@@ -165,6 +167,30 @@ class PostControllerTest {
         //then
         result.andExpect(status().isOk());
         verify(postService, times(1)).getOnePost(anyString(), anyLong());
+    }
+
+    @Test
+    void 이동봉사_중개_모집중_공고_목록_조회() throws Exception {
+        //given
+        Pageable pageable = PageRequest.of(0, 2);
+        List<PostRecruitingGetResponse> response = new ArrayList<>();
+        LocalDate startDate = LocalDate.of(2023, 10, 2);
+        LocalDate endDate = LocalDate.of(2023, 11, 7);
+        response.add(new PostRecruitingGetResponse(1L, PostStatus.RECRUITING, "image1", "포포1", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate));
+        response.add(new PostRecruitingGetResponse(2L, PostStatus.EXPIRED, "image2", "포포2", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate));
+
+
+        //when
+        given(postService.getRecruitingPosts(anyString(), any())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/intermediaries/posts/recruiting")
+        );
+
+        //then
+        result.andExpect(status().isOk());
+        verify(postService, times(1)).getRecruitingPosts(anyString(), any());
     }
 
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #66 

## 📝 작업 내용
- 이동봉사 중개 모집중, 모집 마감 공고 조회 API 구현
- 이동봉사 중개 모집중, 모집 마감 공고 조회 Controller 테스트 코드 추가
- 이동봉사자 봉사 관리 - 승인 대기중, 진행중 공고 id 반환 추가 (이동봉사자 봉사 관리 - 승인 대기중, 진행중 공고 목록 조회 시 공고 id를 반환하도록 변경)

## 💬 리뷰 요구 사항
