### PR TITLE
[Feature] 이동봉사 중개 이동봉사 신청 확정, 반려 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
@@ -111,4 +111,17 @@ public class ApplicationController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "봉사 관리 - 승인 대기중 - 이동봉사자 확인 - 봉사 신청 반려", description = "이동봉사자의 봉사 신청을 반려합니다.",
+            responses = {@ApiResponse(responseCode = "204", description = "봉사 신청 반려 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다. \t\n AP2, 해당 신청 내역을 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @DeleteMapping( "/intermediaries/applications/{applicationId}")
+    public ResponseEntity<Void> cancelApplication(@AuthenticationPrincipal UserDetails loginUser,
+                                                   @PathVariable Long applicationId) {
+        applicationService.cancelApplication(loginUser.getUsername(), applicationId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
@@ -98,4 +98,17 @@ public class ApplicationController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "봉사 관리 - 승인 대기중 - 이동봉사자 확인 - 봉사 신청 확정", description = "이동봉사자의 봉사 신청을 확정합니다.",
+            responses = {@ApiResponse(responseCode = "204", description = "봉사 신청 확정 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다. \t\n AP2, 해당 신청 내역을 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @PatchMapping( "/intermediaries/applications/{applicationId}")
+    public ResponseEntity<Void> confirmApplication(@AuthenticationPrincipal UserDetails loginUser,
+                                                  @PathVariable Long applicationId) {
+        applicationService.confirmApplication(loginUser.getUsername(), applicationId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/entity/Application.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/entity/Application.java
@@ -47,4 +47,8 @@ public class Application extends BaseTimeEntity {
         this.intermediary = intermediary;
         this.volunteer = volunteer;
     }
+
+    public void updateStatus(ApplicationStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
@@ -13,4 +13,5 @@ public interface CustomApplicationRepository {
     List<ApplicationWaitingResponse> getWaitingApplications(Long volunteerId, Pageable pageable);
     List<ApplicationProgressingResponse> getProgressingApplications(Long volunteerId, Pageable pageable);
     Optional<Application> findByIdAndVolunteerIdWithPost(Long applicationId, Long volunteerId);
+    Optional<Application> findByIdAndIntermediaryIdWithPost(Long applicationId, Long intermediaryId);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -73,4 +73,15 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
                         .and(application.volunteer.id.eq(volunteerId)))
                 .fetchOne());
     }
+
+    @Override
+    public Optional<Application> findByIdAndIntermediaryIdWithPost(Long applicationId, Long intermediaryId) {
+        return Optional.ofNullable(queryFactory
+                .select(application)
+                .from(application)
+                .join(application.post, post).fetchJoin()
+                .where(application.id.eq(applicationId)
+                        .and(application.intermediary.id.eq(intermediaryId)))
+                .fetchOne());
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
@@ -91,7 +91,7 @@ public class ApplicationService {
         // 신청 내역 + post
         Application application = customApplicationRepository.findByIdAndVolunteerIdWithPost(applicationId, volunteer.getId()).orElseThrow(() -> new BadRequestException(APPLICATION_NOT_FOUND));
         applicationRepository.delete(application);
-        // 신청 취소 시: 공고 승인 대기중 -> 모집중
+        // 상태 업데이트 (승인 대기중 -> 모집중)
         Post post = application.getPost();
         post.updateStatus(PostStatus.RECRUITING);
     }
@@ -105,5 +105,16 @@ public class ApplicationService {
         // 상태 업데이트 (승인 대기중 -> 진행중)
         application.updateStatus(ApplicationStatus.PROGRESSING);
         post.updateStatus(PostStatus.PROGRESSING);
+    }
+
+    public void cancelApplication(String email, Long applicationId) {
+        // 이동봉사 중개
+        Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
+        // 신청 내역 + post
+        Application application = customApplicationRepository.findByIdAndIntermediaryIdWithPost(applicationId, intermediary.getId()).orElseThrow(() -> new BadRequestException(APPLICATION_NOT_FOUND));
+        applicationRepository.delete(application);
+        // 상태 업데이트 (승인 대기중 -> 모집중)
+        Post post = application.getPost();
+        post.updateStatus(PostStatus.RECRUITING);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
@@ -5,9 +5,11 @@ import com.pawwithu.connectdog.domain.application.dto.response.ApplicationGetOne
 import com.pawwithu.connectdog.domain.application.dto.response.ApplicationProgressingResponse;
 import com.pawwithu.connectdog.domain.application.dto.response.ApplicationWaitingResponse;
 import com.pawwithu.connectdog.domain.application.entity.Application;
+import com.pawwithu.connectdog.domain.application.entity.ApplicationStatus;
 import com.pawwithu.connectdog.domain.application.repository.ApplicationRepository;
 import com.pawwithu.connectdog.domain.application.repository.CustomApplicationRepository;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
+import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
 import com.pawwithu.connectdog.domain.post.entity.Post;
 import com.pawwithu.connectdog.domain.post.entity.PostStatus;
 import com.pawwithu.connectdog.domain.post.repository.PostRepository;
@@ -34,6 +36,7 @@ public class ApplicationService {
     private final PostRepository postRepository;
     private final ApplicationRepository applicationRepository;
     private final CustomApplicationRepository customApplicationRepository;
+    private final IntermediaryRepository intermediaryRepository;
 
     public void volunteerApply(String email, Long postId, VolunteerApplyRequest request) {
         // 이동봉사자
@@ -91,5 +94,16 @@ public class ApplicationService {
         // 신청 취소 시: 공고 승인 대기중 -> 모집중
         Post post = application.getPost();
         post.updateStatus(PostStatus.RECRUITING);
+    }
+
+    public void confirmApplication(String email, Long applicationId) {
+        // 이동봉사 중개
+        Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
+        // 신청 내역 + post
+        Application application = customApplicationRepository.findByIdAndIntermediaryIdWithPost(applicationId, intermediary.getId()).orElseThrow(() -> new BadRequestException(APPLICATION_NOT_FOUND));
+        Post post = application.getPost();
+        // 상태 업데이트 (승인 대기중 -> 진행중)
+        application.updateStatus(ApplicationStatus.PROGRESSING);
+        post.updateStatus(PostStatus.PROGRESSING);
     }
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
@@ -159,4 +159,19 @@ class ApplicationControllerTest {
         result.andExpect(status().isNoContent());
         verify(applicationService, times(1)).confirmApplication(anyString(), anyLong());
     }
+
+    @Test
+    void 이동봉사_신청_반려() throws Exception {
+        //given
+        Long applicationId = 1L;
+
+        //when
+        ResultActions result = mockMvc.perform(
+                delete("/intermediaries/applications/{applicationId}", applicationId)
+        );
+
+        //then
+        result.andExpect(status().isNoContent());
+        verify(applicationService, times(1)).cancelApplication(anyString(), anyLong());
+    }
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
@@ -144,4 +144,19 @@ class ApplicationControllerTest {
         result.andExpect(status().isNoContent());
         verify(applicationService, times(1)).deleteApplication(anyString(), anyLong());
     }
+
+    @Test
+    void 이동봉사_신청_승인() throws Exception {
+        //given
+        Long applicationId = 1L;
+
+        //when
+        ResultActions result = mockMvc.perform(
+                patch("/intermediaries/applications/{applicationId}", applicationId)
+        );
+
+        //then
+        result.andExpect(status().isNoContent());
+        verify(applicationService, times(1)).confirmApplication(anyString(), anyLong());
+    }
 }


### PR DESCRIPTION
## 💡 연관된 이슈
closte #68 

## 📝 작업 내용
- 이동봉사 중개 이동봉사 신청 확정 API 구현
- 이동봉사 중개 이동봉사 신청 확정 Controller 테스트 코드 추가
- 이동봉사 중개 이동봉사 신청 반려 API 구현
- 이동봉사 중개 이동봉사 신청 반려 Controller 테스트 코드 추가

## 💬 리뷰 요구 사항
이동봉사 신청 확정 API를 처음에는 POST로 했다가! 공고와 신청의 상태 변화가 있지만, 새로운 리소스는 생성하지 않아 PATCH로 바꿨습니다!