### PR TITLE
[Feature] 이동봉사 중개 프로필 공고 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryController.java
@@ -1,0 +1,39 @@
+package com.pawwithu.connectdog.domain.intermediary.controller;
+
+import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetPostsResponse;
+import com.pawwithu.connectdog.domain.intermediary.service.IntermediaryService;
+import com.pawwithu.connectdog.error.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "Intermediary", description = "Intermediary API")
+@RestController
+@RequiredArgsConstructor
+public class IntermediaryController {
+
+    private final IntermediaryService intermediaryService;
+
+    @Operation(summary = "중개 프로필 - 이동봉사 공고 목록 조회", description = "중개 프로필에서 이동봉사 공고 목록을 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "이동봉사 공고 목록 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping( "/volunteers/intermediaries/{intermediaryId}/posts")
+    public ResponseEntity<List<IntermediaryGetPostsResponse>> getIntermediaryPosts(@PathVariable Long intermediaryId,
+                                                                                   Pageable pageable) {
+        List<IntermediaryGetPostsResponse> response = intermediaryService.getIntermediaryPosts(intermediaryId, pageable);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/response/IntermediaryGetPostsResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/response/IntermediaryGetPostsResponse.java
@@ -1,0 +1,14 @@
+package com.pawwithu.connectdog.domain.intermediary.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+public record IntermediaryGetPostsResponse(Long postId, String mainImage, String departureLoc, String arrivalLoc,
+                                           @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                           LocalDate startDate,
+                                           @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                           LocalDate endDate,
+                                           String intermediaryName,
+                                           Boolean isKennel) {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
@@ -1,0 +1,34 @@
+package com.pawwithu.connectdog.domain.intermediary.service;
+
+import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetPostsResponse;
+import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
+import com.pawwithu.connectdog.domain.post.repository.CustomPostRepository;
+import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.pawwithu.connectdog.error.ErrorCode.INTERMEDIARY_NOT_FOUND;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class IntermediaryService {
+
+    private final IntermediaryRepository intermediaryRepository;
+    private final CustomPostRepository customPostRepository;
+
+    public List<IntermediaryGetPostsResponse> getIntermediaryPosts(Long intermediaryId, Pageable pageable) {
+        // 이동봉사 중개
+        if (!intermediaryRepository.existsById(intermediaryId)){
+            throw new BadRequestException(INTERMEDIARY_NOT_FOUND);
+        }
+        List<IntermediaryGetPostsResponse> intermediaryPosts = customPostRepository.getIntermediaryPosts(intermediaryId, pageable);
+        return intermediaryPosts;
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostGetHomeResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostGetHomeResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDate;
 
-public record PostGetHomeResponse(String mainImage, String departureLoc, String arrivalLoc,
+public record PostGetHomeResponse(Long postId, String mainImage, String departureLoc, String arrivalLoc,
                                   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                   LocalDate startDate,
                                   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")

--- a/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostGetOneResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostGetOneResponse.java
@@ -8,7 +8,7 @@ import com.pawwithu.connectdog.domain.post.entity.PostStatus;
 import java.time.LocalDate;
 import java.util.List;
 
-public record PostGetOneResponse(String mainImage, List<String> images, String postStatus,
+public record PostGetOneResponse(Long postId, String mainImage, List<String> images, String postStatus,
                                  String departureLoc, String arrivalLoc,
                                  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                  LocalDate startDate,
@@ -21,18 +21,18 @@ public record PostGetOneResponse(String mainImage, List<String> images, String p
                                  Boolean isBookmark) {
 
     // 공고 이미지 필드를 제외한 생성자
-    public PostGetOneResponse(String mainImage, PostStatus postStatus, String departureLoc, String arrivalLoc,
+    public PostGetOneResponse(Long postId, String mainImage, PostStatus postStatus, String departureLoc, String arrivalLoc,
             LocalDate startDate, LocalDate endDate, String pickUpTime, Boolean isKennel, String content, String dogName,
             DogSize dogSize, DogGender dogGender, Float dogWeight, String specifics, Long intermediaryId,
             String intermediaryProfileImage, String intermediaryName) {
-        this(mainImage, null, postStatus.getKey(), departureLoc, arrivalLoc, startDate, endDate,
+        this(postId, mainImage, null, postStatus.getKey(), departureLoc, arrivalLoc, startDate, endDate,
                 pickUpTime, isKennel, content, dogName, dogSize.getKey(), dogGender.getKey(), dogWeight, specifics,
                 intermediaryId, intermediaryProfileImage, intermediaryName, null);
     }
 
     // 공고 이미지, 북마크 여부를 포함한 생성자
     public static PostGetOneResponse of(PostGetOneResponse response, List<String> images, Boolean isBookmark) {
-        return new PostGetOneResponse(response.mainImage, images, response.postStatus, response.departureLoc, response.arrivalLoc,
+        return new PostGetOneResponse(response.postId, response.mainImage, images, response.postStatus, response.departureLoc, response.arrivalLoc,
                 response.startDate, response.endDate, response.pickUpTime, response.isKennel, response.content,
                 response.dogName, response.dogSize, response.dogGender, response.dogWeight, response.specifics,
                 response.intermediaryId, response.intermediaryProfileImage, response.intermediaryName, isBookmark);

--- a/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostSearchResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostSearchResponse.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.time.LocalDate;
 
-public record PostSearchResponse(String mainImage, String departureLoc, String arrivalLoc,
+public record PostSearchResponse(Long postId, String mainImage, String departureLoc, String arrivalLoc,
                                  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                  LocalDate startDate,
                                  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
@@ -1,5 +1,6 @@
 package com.pawwithu.connectdog.domain.post.repository;
 
+import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetPostsResponse;
 import com.pawwithu.connectdog.domain.post.dto.request.PostSearchRequest;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetOneResponse;
@@ -20,4 +21,5 @@ public interface CustomPostRepository {
     // 공고 상세 조회 (대표 이미지를 제외한 다른 이미지 포함 X)
     PostGetOneResponse getOnePost(Long volunteerId, Long postId);
     List<PostRecruitingGetResponse> getRecruitingPosts(Long intermediaryId, Pageable pageable);
+    List<IntermediaryGetPostsResponse> getIntermediaryPosts(Long intermediaryId, Pageable pageable);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
@@ -1,6 +1,7 @@
 package com.pawwithu.connectdog.domain.post.repository.impl;
 
 import com.pawwithu.connectdog.domain.dog.entity.DogSize;
+import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetPostsResponse;
 import com.pawwithu.connectdog.domain.post.dto.request.PostSearchRequest;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetOneResponse;
@@ -111,6 +112,24 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                 .offset(pageable.getOffset())   // 페이지 번호
                 .limit(pageable.getPageSize())  // 페이지 사이즈
                 .fetch();
+    }
+
+    @Override
+    public List<IntermediaryGetPostsResponse> getIntermediaryPosts(Long intermediaryId, Pageable pageable) {
+        return queryFactory
+                .select(Projections.constructor(IntermediaryGetPostsResponse.class,
+                        post.id, postImage.image, post.departureLoc, post.arrivalLoc, post.startDate, post.endDate,
+                        intermediary.name, post.isKennel))
+                .from(post)
+                .join(post.intermediary, intermediary)
+                .join(post.mainImage, postImage)
+                .where(post.intermediary.id.eq(intermediaryId)
+                        .and(post.status.eq(PostStatus.RECRUITING)))    // 모집중인 공고
+                .orderBy(post.createdDate.desc())   // 최신순
+                .offset(pageable.getOffset())   // 페이지 번호
+                .limit(pageable.getPageSize())  // 페이지 사이즈
+                .fetch();
+
     }
 
     // 모든 필터 검색

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
@@ -56,7 +56,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
 
         return queryFactory
                 .select(Projections.constructor(PostSearchResponse.class,
-                        postImage.image, post.departureLoc, post.arrivalLoc, post.startDate, post.endDate,
+                        post.id, postImage.image, post.departureLoc, post.arrivalLoc, post.startDate, post.endDate,
                         intermediary.name, post.isKennel))
                 .from(post)
                 .join(post.intermediary, intermediary)

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
@@ -40,7 +40,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
     public List<PostGetHomeResponse> getHomePosts() {
         return queryFactory
                         .select(Projections.constructor(PostGetHomeResponse.class,
-                                postImage.image, post.departureLoc, post.arrivalLoc, post.startDate, post.endDate,
+                                post.id, postImage.image, post.departureLoc, post.arrivalLoc, post.startDate, post.endDate,
                                 intermediary.name, post.isKennel))
                         .from(post)
                         .join(post.intermediary, intermediary)

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
@@ -85,7 +85,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
     public PostGetOneResponse getOnePost(Long volunteerId, Long postId) {
         return queryFactory
                 .select(Projections.constructor(PostGetOneResponse.class,
-                        postImage.image, post.status, post.departureLoc, post.arrivalLoc,
+                        post.id, postImage.image, post.status, post.departureLoc, post.arrivalLoc,
                         post.startDate, post.endDate, post.pickUpTime, post.isKennel, post.content,
                         dog.name, dog.size, dog.gender, dog.weight, dog.specifics,
                         intermediary.id, intermediary.profileImage, intermediary.name))

--- a/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
@@ -1,0 +1,77 @@
+package com.pawwithu.connectdog.domain.intermediary.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetPostsResponse;
+import com.pawwithu.connectdog.domain.intermediary.service.IntermediaryService;
+import com.pawwithu.connectdog.domain.post.dto.response.PostRecruitingGetResponse;
+import com.pawwithu.connectdog.domain.post.entity.PostStatus;
+import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class IntermediaryControllerTest {
+
+    @InjectMocks
+    private IntermediaryController intermediaryController;
+    @Mock
+    private IntermediaryService intermediaryService;
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(intermediaryController)
+                .setCustomArgumentResolvers(new TestUserArgumentResolver(), new PageableHandlerMethodArgumentResolver())
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+
+    @Test
+    void 이동봉사_중개_모집중_공고_목록_조회() throws Exception {
+        //given
+        Long intermediaryId = 1L;
+        Pageable pageable = PageRequest.of(0, 2);
+        List<IntermediaryGetPostsResponse> response = new ArrayList<>();
+        LocalDate startDate = LocalDate.of(2023, 10, 2);
+        LocalDate endDate = LocalDate.of(2023, 11, 7);
+        response.add(new IntermediaryGetPostsResponse(1L, "image1", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "중개자하노정", false));
+        response.add(new IntermediaryGetPostsResponse(2L, "image2", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "중개자하노정", true));
+
+
+        //when
+        given(intermediaryService.getIntermediaryPosts(anyLong(), any())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/volunteers/intermediaries/{intermediaryId}/posts", intermediaryId)
+        );
+
+        //then
+        result.andExpect(status().isOk());
+        verify(intermediaryService, times(1)).getIntermediaryPosts(anyLong(), any());
+    }
+
+}

--- a/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
@@ -93,9 +93,9 @@ class PostControllerTest {
         List<PostGetHomeResponse> response = new ArrayList<>();
         LocalDate startDate = LocalDate.of(2023, 10, 2);
         LocalDate endDate = LocalDate.of(2023, 11, 7);
-        response.add(new PostGetHomeResponse("image1", "서울시 성북구", "서울시 중랑구",
+        response.add(new PostGetHomeResponse(1L, "image1", "서울시 성북구", "서울시 중랑구",
                 startDate, endDate, "이동봉사 중개", true));
-        response.add(new PostGetHomeResponse("image2", "서울시 성북구", "서울시 중랑구",
+        response.add(new PostGetHomeResponse(2L, "image2", "서울시 성북구", "서울시 중랑구",
                 startDate, endDate, "이동봉사 중개", false));
 
         //when
@@ -116,9 +116,9 @@ class PostControllerTest {
         List<PostSearchResponse> response = new ArrayList<>();
         LocalDate startDate = LocalDate.of(2023, 10, 2);
         LocalDate endDate = LocalDate.of(2023, 11, 7);
-        response.add(new PostSearchResponse("image1", "서울시 성북구", "서울시 중랑구",
+        response.add(new PostSearchResponse(1L, "image1", "서울시 성북구", "서울시 중랑구",
                 startDate, endDate, "이동봉사 중개", true));
-        response.add(new PostSearchResponse("image2", "서울시 성북구", "서울시 중랑구",
+        response.add(new PostSearchResponse(2L, "image2", "서울시 성북구", "서울시 중랑구",
                 startDate, endDate, "이동봉사 중개", false));
 
 
@@ -153,7 +153,7 @@ class PostControllerTest {
         List<String> images = new ArrayList<>();
         images.add("image1");
         images.add("image2");
-        PostGetOneResponse response = new PostGetOneResponse("mainImage", images, "모집중", "서울시 성북구", "서울시 중랑구",
+        PostGetOneResponse response = new PostGetOneResponse(1L, "mainImage", images, "모집중", "서울시 성북구", "서울시 중랑구",
                 startDate, endDate, "12:00", true, "이동봉사 공고", "봄이", DogSize.SMALL.getKey(),
                 DogGender.FEMALE.getKey(), 5.1f, "ㄱㅇㅇ", 1L, "profileImage", "이동봉사 중개", true);
 


### PR DESCRIPTION
## 💡 연관된 이슈
close #74 

## 📝 작업 내용
- 이동봉사 중개 프로필 공고 목록 조회 API 구현
- 이동봉사 중개 프로필 공고 목록 조회 Controller 테스트 코드 추가
- 홈 화면 공고 5개 조회, 공고 필터별 검색, 공고 상세 보기 시 postId 추가 반환하도록 수정
- dto 수정에 따른 테스트 코드 수정

이전에 구현했던 공고 관련 API에서 공고 id를 추가 반환하도록 했습니다!

## 💬 리뷰 요구 사항
