### PR TITLE
[Feature] 이동봉사자, 이동봉사 중개 봉사 완료 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
@@ -160,4 +160,17 @@ public class ApplicationController {
         List<ApplicationVolunteerCompletedResponse> response = applicationService.getVolunteerCompletedApplications(loginUser.getUsername(), pageable);
         return ResponseEntity.ok(response);
     }
+
+    @Operation(summary = "봉사 관리 - 봉사 완료 목록 조회", description = "이동봉사 완료 목록을 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "이동봉사 완료 목록 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping( "/intermediaries/applications/completed")
+    public ResponseEntity<List<ApplicationIntermediaryCompletedResponse>> getIntermediaryCompletedApplications(@AuthenticationPrincipal UserDetails loginUser,
+                                                                                                                   Pageable pageable) {
+        List<ApplicationIntermediaryCompletedResponse> response = applicationService.getIntermediaryCompletedApplications(loginUser.getUsername(), pageable);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
@@ -147,4 +147,17 @@ public class ApplicationController {
         List<ApplicationIntermediaryProgressingResponse> response = applicationService.getIntermediaryProgressingApplications(loginUser.getUsername(), pageable);
         return ResponseEntity.ok(response);
     }
+
+    @Operation(summary = "봉사 관리 - 봉사 완료 목록 조회", description = "이동봉사 완료 목록을 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "이동봉사 완료 목록 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M1, 해당 이동봉사자를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping( "/volunteers/applications/completed")
+    public ResponseEntity<List<ApplicationVolunteerCompletedResponse>> getVolunteerCompletedApplications(@AuthenticationPrincipal UserDetails loginUser,
+                                                                                                                   Pageable pageable) {
+        List<ApplicationVolunteerCompletedResponse> response = applicationService.getVolunteerCompletedApplications(loginUser.getUsername(), pageable);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationIntermediaryCompletedResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationIntermediaryCompletedResponse.java
@@ -1,0 +1,15 @@
+package com.pawwithu.connectdog.domain.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+public record ApplicationIntermediaryCompletedResponse(Long postId, String mainImage, String dogName,
+                                                       @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                                       LocalDate startDate,
+                                                       @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                                       LocalDate endDate,
+                                                       String departureLoc, String arrivalLoc,
+                                                       String volunteerName, Long applicationId,
+                                                       Long reviewId, Long dogStatusId) {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationVolunteerCompletedResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationVolunteerCompletedResponse.java
@@ -1,0 +1,16 @@
+package com.pawwithu.connectdog.domain.application.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+public record ApplicationVolunteerCompletedResponse(Long postId, String mainImage,
+                                                    String departureLoc, String arrivalLoc,
+                                                    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                                    LocalDate startDate,
+                                                    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                                    LocalDate endDate,
+                                                    String intermediaryName, Boolean isKennel,
+                                                    Long reviewId, Long dogStatusId) {
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
@@ -16,4 +16,5 @@ public interface CustomApplicationRepository {
     List<ApplicationIntermediaryWaitingResponse> getIntermediaryWaitingApplications(Long intermediaryId, Pageable pageable);
     List<ApplicationIntermediaryProgressingResponse> getIntermediaryProgressingApplications(Long intermediaryId, Pageable pageable);
     List<ApplicationVolunteerCompletedResponse> getVolunteerCompletedApplications(Long volunteerId, Pageable pageable);
+    List<ApplicationIntermediaryCompletedResponse> getIntermediaryCompletedApplications(Long intermediaryId, Pageable pageable);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
@@ -1,9 +1,6 @@
 package com.pawwithu.connectdog.domain.application.repository;
 
-import com.pawwithu.connectdog.domain.application.dto.response.ApplicationIntermediaryProgressingResponse;
-import com.pawwithu.connectdog.domain.application.dto.response.ApplicationIntermediaryWaitingResponse;
-import com.pawwithu.connectdog.domain.application.dto.response.ApplicationVolunteerProgressingResponse;
-import com.pawwithu.connectdog.domain.application.dto.response.ApplicationVolunteerWaitingResponse;
+import com.pawwithu.connectdog.domain.application.dto.response.*;
 import com.pawwithu.connectdog.domain.application.entity.Application;
 import org.springframework.data.domain.Pageable;
 
@@ -18,4 +15,5 @@ public interface CustomApplicationRepository {
     Optional<Application> findByIdAndIntermediaryIdWithPost(Long applicationId, Long intermediaryId);
     List<ApplicationIntermediaryWaitingResponse> getIntermediaryWaitingApplications(Long intermediaryId, Pageable pageable);
     List<ApplicationIntermediaryProgressingResponse> getIntermediaryProgressingApplications(Long intermediaryId, Pageable pageable);
+    List<ApplicationVolunteerCompletedResponse> getVolunteerCompletedApplications(Long volunteerId, Pageable pageable);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -1,9 +1,6 @@
 package com.pawwithu.connectdog.domain.application.repository.impl;
 
-import com.pawwithu.connectdog.domain.application.dto.response.ApplicationIntermediaryProgressingResponse;
-import com.pawwithu.connectdog.domain.application.dto.response.ApplicationIntermediaryWaitingResponse;
-import com.pawwithu.connectdog.domain.application.dto.response.ApplicationVolunteerProgressingResponse;
-import com.pawwithu.connectdog.domain.application.dto.response.ApplicationVolunteerWaitingResponse;
+import com.pawwithu.connectdog.domain.application.dto.response.*;
 import com.pawwithu.connectdog.domain.application.entity.Application;
 import com.pawwithu.connectdog.domain.application.entity.ApplicationStatus;
 import com.pawwithu.connectdog.domain.application.repository.CustomApplicationRepository;
@@ -19,9 +16,11 @@ import java.util.Optional;
 
 import static com.pawwithu.connectdog.domain.application.entity.QApplication.application;
 import static com.pawwithu.connectdog.domain.dog.entity.QDog.dog;
+import static com.pawwithu.connectdog.domain.dogStatus.entity.QDogStatus.dogStatus;
 import static com.pawwithu.connectdog.domain.intermediary.entity.QIntermediary.intermediary;
 import static com.pawwithu.connectdog.domain.post.entity.QPost.post;
 import static com.pawwithu.connectdog.domain.post.entity.QPostImage.postImage;
+import static com.pawwithu.connectdog.domain.review.entity.QReview.review;
 import static com.pawwithu.connectdog.domain.volunteer.entity.QVolunteer.volunteer;
 
 @Repository
@@ -122,6 +121,26 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
                 .where(application.status.eq(ApplicationStatus.PROGRESSING)
                         .and(application.intermediary.id.eq(intermediaryId)))
                 .orderBy(application.modifiedDate.desc())   // 신청 확정 최신순
+                .offset(pageable.getOffset())   // 페이지 번호
+                .limit(pageable.getPageSize())  // 페이지 사이즈
+                .fetch();
+    }
+
+    @Override
+    public List<ApplicationVolunteerCompletedResponse> getVolunteerCompletedApplications(Long volunteerId, Pageable pageable) {
+        return queryFactory
+                .select(Projections.constructor(ApplicationVolunteerCompletedResponse.class,
+                        post.id, postImage.image, post.departureLoc, post.arrivalLoc, post.startDate, post.endDate,
+                        intermediary.name, post.isKennel, review.id, dogStatus.id))
+                .from(application)
+                .join(application.post, post)
+                .join(application.post.intermediary, intermediary)
+                .join(application.post.mainImage, postImage)
+                .leftJoin(review).on(post.id.eq(review.post.id))
+                .leftJoin(dogStatus).on(post.id.eq(dogStatus.post.id))
+                .where(application.status.eq(ApplicationStatus.COMPLETED)
+                        .and(application.volunteer.id.eq(volunteerId)))
+                .orderBy(application.modifiedDate.desc())   // 신청 봉사완료 최신순
                 .offset(pageable.getOffset())   // 페이지 번호
                 .limit(pageable.getPageSize())  // 페이지 사이즈
                 .fetch();

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -145,4 +145,25 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
                 .limit(pageable.getPageSize())  // 페이지 사이즈
                 .fetch();
     }
+
+    @Override
+    public List<ApplicationIntermediaryCompletedResponse> getIntermediaryCompletedApplications(Long intermediaryId, Pageable pageable) {
+        return queryFactory
+                .select(Projections.constructor(ApplicationIntermediaryCompletedResponse.class,
+                        post.id, postImage.image, dog.name, post.startDate, post.endDate, post.departureLoc, post.arrivalLoc,
+                        volunteer.name, application.id, review.id, dogStatus.id))
+                .from(application)
+                .join(application.post, post)
+                .join(application.post.mainImage, postImage)
+                .join(application.post.dog, dog)
+                .join(application.volunteer, volunteer)
+                .leftJoin(review).on(post.id.eq(review.post.id))
+                .leftJoin(dogStatus).on(post.id.eq(dogStatus.post.id))
+                .where(application.status.eq(ApplicationStatus.COMPLETED)
+                        .and(application.intermediary.id.eq(intermediaryId)))
+                .orderBy(application.modifiedDate.desc())   // 신청 봉사완료 최신순
+                .offset(pageable.getOffset())   // 페이지 번호
+                .limit(pageable.getPageSize())  // 페이지 사이즈
+                .fetch();
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
@@ -140,4 +140,11 @@ public class ApplicationService {
         List<ApplicationVolunteerCompletedResponse> completedApplications = customApplicationRepository.getVolunteerCompletedApplications(volunteer.getId(), pageable);
         return completedApplications;
     }
+
+    public List<ApplicationIntermediaryCompletedResponse> getIntermediaryCompletedApplications(String email, Pageable pageable) {
+        // 이동봉사 중개
+        Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
+        List<ApplicationIntermediaryCompletedResponse> completedApplications = customApplicationRepository.getIntermediaryCompletedApplications(intermediary.getId(), pageable);
+        return completedApplications;
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
@@ -6,11 +6,13 @@ import com.pawwithu.connectdog.domain.application.entity.Application;
 import com.pawwithu.connectdog.domain.application.entity.ApplicationStatus;
 import com.pawwithu.connectdog.domain.application.repository.ApplicationRepository;
 import com.pawwithu.connectdog.domain.application.repository.CustomApplicationRepository;
+import com.pawwithu.connectdog.domain.dogStatus.repository.DogStatusRepository;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
 import com.pawwithu.connectdog.domain.post.entity.Post;
 import com.pawwithu.connectdog.domain.post.entity.PostStatus;
 import com.pawwithu.connectdog.domain.post.repository.PostRepository;
+import com.pawwithu.connectdog.domain.review.repository.ReviewRepository;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import com.pawwithu.connectdog.domain.volunteer.repository.VolunteerRepository;
 import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
@@ -35,6 +37,8 @@ public class ApplicationService {
     private final ApplicationRepository applicationRepository;
     private final CustomApplicationRepository customApplicationRepository;
     private final IntermediaryRepository intermediaryRepository;
+    private final ReviewRepository reviewRepository;
+    private final DogStatusRepository dogStatusRepository;
 
     public void volunteerApply(String email, Long postId, VolunteerApplyRequest request) {
         // 이동봉사자
@@ -128,5 +132,12 @@ public class ApplicationService {
         Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
         List<ApplicationIntermediaryProgressingResponse> progressingApplications = customApplicationRepository.getIntermediaryProgressingApplications(intermediary.getId(), pageable);
         return progressingApplications;
+    }
+
+    public List<ApplicationVolunteerCompletedResponse> getVolunteerCompletedApplications(String email, Pageable pageable) {
+        // 이동봉사자
+        Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
+        List<ApplicationVolunteerCompletedResponse> completedApplications = customApplicationRepository.getVolunteerCompletedApplications(volunteer.getId(), pageable);
+        return completedApplications;
     }
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
@@ -224,7 +224,7 @@ class ApplicationControllerTest {
     }
 
     @Test
-    void 이동봉사_완료_목록_조회() throws Exception {
+    void 이동봉사자_봉사완료_목록_조회() throws Exception {
         //given
         List<ApplicationVolunteerCompletedResponse> response = new ArrayList<>();
         LocalDate startDate = LocalDate.of(2023, 10, 2);
@@ -243,6 +243,32 @@ class ApplicationControllerTest {
         //then
         result.andExpect(status().isOk());
         verify(applicationService, times(1)).getVolunteerCompletedApplications(anyString(), any());
+    }
+
+    @Test
+    void 이동봉사_중개_봉사완료_목록_조회() throws Exception {
+        //given
+        List<ApplicationIntermediaryCompletedResponse> response = new ArrayList<>();
+        LocalDate startDate = LocalDate.of(2023, 10, 2);
+        LocalDate endDate = LocalDate.of(2023, 11, 7);
+        response.add(new ApplicationIntermediaryCompletedResponse(1L, "image1", "포포",
+                startDate, endDate, "이동봉사 중개", "서울시 성북구", "서울시 중랑구",
+                1L, 1L, null));
+        response.add(new ApplicationIntermediaryCompletedResponse(2L, "image1", "포포",
+                startDate, endDate, "이동봉사 중개", "서울시 성북구", "서울시 중랑구",
+                1L, 1L, null));
+
+        //when
+        given(applicationService.getIntermediaryCompletedApplications(anyString(), any())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/intermediaries/applications/completed")
+                        .param("page", "0")
+                        .param("size", "2")
+        );
+
+        //then
+        result.andExpect(status().isOk());
+        verify(applicationService, times(1)).getIntermediaryCompletedApplications(anyString(), any());
     }
 
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
@@ -223,4 +223,26 @@ class ApplicationControllerTest {
         verify(applicationService, times(1)).getIntermediaryProgressingApplications(anyString(), any());
     }
 
+    @Test
+    void 이동봉사_완료_목록_조회() throws Exception {
+        //given
+        List<ApplicationVolunteerCompletedResponse> response = new ArrayList<>();
+        LocalDate startDate = LocalDate.of(2023, 10, 2);
+        LocalDate endDate = LocalDate.of(2023, 11, 7);
+        response.add(new ApplicationVolunteerCompletedResponse(1L, "image1", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "이동봉사 중개", true, 1L, null));
+        response.add(new ApplicationVolunteerCompletedResponse(2L, "image2", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "이동봉사 중개", false, null, null));
+
+        //when
+        given(applicationService.getVolunteerCompletedApplications(anyString(), any())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/volunteers/applications/completed")
+        );
+
+        //then
+        result.andExpect(status().isOk());
+        verify(applicationService, times(1)).getVolunteerCompletedApplications(anyString(), any());
+    }
+
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #76 

## 📝 작업 내용
- 이동봉사자 봉사 완료 목록 조회 API 구현
- 이동봉사자 봉사 완료 목록 조회 Controller 테스트 코드 추가
- 이동봉사 중개 봉사 완료 목록 조회 API 구현
- 이동봉사 중개 봉사 완료 목록 조회 Controller 테스트 코드 추가

## 💬 리뷰 요구 사항
저희가 놓치는 부분이 있었던 것 같습니다! 
해당 테이블에 다른 테이블의 외래키가 존재하지 않더라도 join으로 조건을 추가해서 가져온다면 쿼리를 더 줄일 수 있을 것 같아요.
다른 API도 리팩토링 하면서 성능을 개선해 나가면 좋을 것 같습니다!
