### PR TITLE
[Refactor] 이동봉사 중개 강아지 근황 단건 조회 API 쿼리 수정

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/repository/impl/CustomDogStatusRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/repository/impl/CustomDogStatusRepositoryImpl.java
@@ -40,20 +40,16 @@ public class CustomDogStatusRepositoryImpl implements CustomDogStatusRepository 
     // 근황 단건 조회 (대표 이미지를 제외한 다른 이미지 포함 X)
     @Override
     public DogStatusGetOneResponse getOneDogStatus(Long id, Long dogStatusId) {
-
         return queryFactory
                 .select(Projections.constructor(DogStatusGetOneResponse.class,
-                        dog.name,
-                        JPAExpressions.select(volunteer.nickname)
-                                .from(application)
-                                .where(application.post.id.eq(dogStatus.post.id))
-                        , dogStatusImage.image,
+                        dog.name,volunteer.nickname, dogStatusImage.image,
                         post.startDate, post.endDate, post.departureLoc, post.arrivalLoc,
                         dogStatus.content))
                 .from(dogStatus)
                 .join(dogStatus.intermediary, intermediary)
                 .join(dogStatus.mainImage, dogStatusImage)
                 .join(dogStatus.post, post)
+                .join(application).on(application.post.id.eq(dogStatus.post.id))
                 .where(dogStatus.id.eq(dogStatusId))
                 .fetchOne();
 


### PR DESCRIPTION
## 💡 연관된 이슈
close #78 

## 📝 작업 내용
- 이동봉사 중개 강아지 근황 단건 조회 API 쿼리 수정 (서브 쿼리 사용하여 총 2번 나가는 쿼리 -> join에 on 조건 사용하여 1번으로 줄이기)

## 💬 리뷰 요구 사항
