### PR TITLE
[Feature] 이동봉사 중개 공고 삭제 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
@@ -92,4 +92,17 @@ public class PostController {
         List<PostRecruitingGetResponse> response = postService.getRecruitingPosts(loginUser.getUsername(), pageable);
         return ResponseEntity.ok(response);
     }
+
+    @Operation(summary = "봉사 관리 - 모집중, 모집 마감", description = "이동봉사 모집중, 모집 마감 목록을 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "이동봉사 모집중, 모집 마감 목록 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다. \t\n P2, 해당 공고를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @DeleteMapping( "/intermediaries/posts/{postId}")
+    public ResponseEntity<Void> deletePost(@AuthenticationPrincipal UserDetails loginUser, @PathVariable Long postId) {
+        postService.deletePost(loginUser.getUsername(), postId);
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/PostImageRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/PostImageRepository.java
@@ -4,4 +4,6 @@ import com.pawwithu.connectdog.domain.post.entity.PostImage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PostImageRepository extends JpaRepository<PostImage, Long> {
+
+    void deleteAllByPostId(Long postId);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/PostRepository.java
@@ -3,5 +3,9 @@ package com.pawwithu.connectdog.domain.post.repository;
 import com.pawwithu.connectdog.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    Optional<Post> findByIdAndIntermediaryId(Long id, Long intermediaryId);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/service/PostService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/service/PostService.java
@@ -107,4 +107,15 @@ public class PostService {
         List<PostRecruitingGetResponse> recruitingPosts = customPostRepository.getRecruitingPosts(intermediary.getId(), pageable);
         return recruitingPosts;
     }
+
+    public void deletePost(String email, Long postId) {
+        // 이동봉사 중개
+        Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
+        // 공고
+        Post post = postRepository.findByIdAndIntermediaryId(postId, intermediary.getId()).orElseThrow(() -> new BadRequestException(POST_NOT_FOUND));
+        // 공고 이미지, 공고, 강아지 삭제
+        postImageRepository.deleteAllByPostId(postId);
+        postRepository.deleteById(post.getId());
+        dogRepository.deleteById(post.getDog().getId());
+    }
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
@@ -32,6 +32,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -191,6 +192,21 @@ class PostControllerTest {
         //then
         result.andExpect(status().isOk());
         verify(postService, times(1)).getRecruitingPosts(anyString(), any());
+    }
+
+    @Test
+    void 이동봉사_중개_공고_삭제() throws Exception {
+        //given
+        Long postId = 1L;
+
+        //when
+        ResultActions result = mockMvc.perform(
+                delete("/intermediaries/posts/{postId}", postId)
+        );
+
+        //then
+        result.andExpect(status().isNoContent());
+        verify(postService, times(1)).deletePost(anyString(), anyLong());
     }
 
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #84 

## 📝 작업 내용
- 이동봉사 중개 공고 삭제 API 구현
- 이동봉사 중개 공고 삭제 Controller 테스트 코드 추가

## 💬 리뷰 요구 사항
공고 삭제 시 QueryDsl을 사용했을 때 외래키 관련 에러가 뜨는데 추후에 리팩토링 할 예정입니다!
혹시 좋은 방법 있다면 같이 얘기해봐요 ~~
