### PR TITLE
[Feature] 이동봉사 중개 프로필 후기 조회 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/dto/response/DogStatusGetOneResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/dto/response/DogStatusGetOneResponse.java
@@ -13,14 +13,14 @@ public record DogStatusGetOneResponse(String dogName, String volunteerNickname, 
                                       String departureLoc, String arrivalLoc,
                                       String content
 ) {
-    // 리뷰 이미지 리스트 필드를 제외한 생성자
+    // 근황 이미지 리스트 필드를 제외한 생성자
     public DogStatusGetOneResponse(String dogName, String volunteerNickname, String mainImage,
                                 LocalDate startDate, LocalDate endDate, String departureLoc, String arrivalLoc,
                                 String content) {
         this(dogName, volunteerNickname, mainImage, null, startDate, endDate, departureLoc, arrivalLoc, content);
     }
 
-    // 리뷰 이미지 리스트 필드를 포함한 생성자
+    // 근황 이미지 리스트 필드를 포함한 생성자
     public static DogStatusGetOneResponse of(DogStatusGetOneResponse response, List<String> images) {
         return new DogStatusGetOneResponse(response.dogName, response.volunteerNickname, response.mainImage, images,
                 response.startDate, response.endDate, response.departureLoc, response.arrivalLoc, response.content);

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryController.java
@@ -2,6 +2,7 @@ package com.pawwithu.connectdog.domain.intermediary.controller;
 
 import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetInfoResponse;
 import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetPostsResponse;
+import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetReviewsResponse;
 import com.pawwithu.connectdog.domain.intermediary.service.IntermediaryService;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -47,6 +48,19 @@ public class IntermediaryController {
     @GetMapping("/volunteers/intermediaries/{intermediaryId}")
     public ResponseEntity<IntermediaryGetInfoResponse> getIntermediaryInfo(@PathVariable Long intermediaryId) {
         IntermediaryGetInfoResponse response = intermediaryService.getIntermediaryInfo(intermediaryId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "중개 프로필 - 후기 조회", description = "중개 프로필에서 후기를 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "중개 프로필 후기 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping("/volunteers/intermediaries/{intermediaryId}/reviews")
+    public ResponseEntity<List<IntermediaryGetReviewsResponse>> getIntermediaryReviews(@PathVariable Long intermediaryId,
+                                                                                       Pageable pageable) {
+        List<IntermediaryGetReviewsResponse> response = intermediaryService.getIntermediaryReviews(intermediaryId, pageable);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/response/IntermediaryGetReviewsResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/response/IntermediaryGetReviewsResponse.java
@@ -1,0 +1,28 @@
+package com.pawwithu.connectdog.domain.intermediary.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import java.util.List;
+
+public record IntermediaryGetReviewsResponse(String dogName, String volunteerNickname, String mainImage, List<String> images,
+                                             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                             LocalDate startDate,
+                                             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                             LocalDate endDate,
+                                             String departureLoc, String arrivalLoc,
+                                             String intermediaryName, String content
+) {
+
+    // 후기 이미지 리스트 필드를 제외한 생성자
+    public IntermediaryGetReviewsResponse(String dogName, String volunteerNickname, String mainImage,
+                                LocalDate startDate, LocalDate endDate, String departureLoc, String arrivalLoc,
+                                String intermediaryName, String content) {
+        this(dogName, volunteerNickname, mainImage, null, startDate, endDate, departureLoc, arrivalLoc, intermediaryName, content);
+    }
+
+    // 후기 이미지 리스트 필드를 포함한 생성자
+    public static IntermediaryGetReviewsResponse of(IntermediaryGetReviewsResponse response, List<String> images) {
+        return new IntermediaryGetReviewsResponse(response.dogName, response.volunteerNickname, response.mainImage, images,
+                response.startDate, response.endDate, response.departureLoc, response.arrivalLoc, response.intermediaryName, response.content);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
@@ -2,9 +2,11 @@ package com.pawwithu.connectdog.domain.intermediary.service;
 
 import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetInfoResponse;
 import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetPostsResponse;
+import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetReviewsResponse;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
 import com.pawwithu.connectdog.domain.post.repository.CustomPostRepository;
+import com.pawwithu.connectdog.domain.review.repository.CustomReviewRepository;
 import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -24,6 +26,7 @@ public class IntermediaryService {
 
     private final IntermediaryRepository intermediaryRepository;
     private final CustomPostRepository customPostRepository;
+    private final CustomReviewRepository customReviewRepository;
 
     @Transactional(readOnly = true)
     public List<IntermediaryGetPostsResponse> getIntermediaryPosts(Long intermediaryId, Pageable pageable) {
@@ -42,5 +45,15 @@ public class IntermediaryService {
         Long completedPostCount =  customPostRepository.getCountOfCompletedPosts(intermediaryId);
         IntermediaryGetInfoResponse intermediaryInfo = IntermediaryGetInfoResponse.from(intermediary, completedPostCount);
         return intermediaryInfo;
+    }
+
+    @Transactional(readOnly = true)
+    public List<IntermediaryGetReviewsResponse> getIntermediaryReviews(Long intermediaryId, Pageable pageable) {
+        // 이동봉사 중개
+        if (!intermediaryRepository.existsById(intermediaryId)){
+            throw new BadRequestException(INTERMEDIARY_NOT_FOUND);
+        }
+        List<IntermediaryGetReviewsResponse> intermediaryReviews = customReviewRepository.getIntermediaryReviews(intermediaryId, pageable);
+        return intermediaryReviews;
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/controller/ReviewController.java
@@ -67,8 +67,8 @@ public class ReviewController {
             })
     @GetMapping(value = "/volunteers/reviews")
     public ResponseEntity<List<ReviewGetAllResponse>> getAllReviews(Pageable pageable) {
-        List<ReviewGetAllResponse> reviews = reviewService.getAllReviews(pageable);
-        return ResponseEntity.ok(reviews);
+        List<ReviewGetAllResponse> response = reviewService.getAllReviews(pageable);
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/review/dto/response/ReviewGetAllResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/dto/response/ReviewGetAllResponse.java
@@ -14,14 +14,14 @@ public record ReviewGetAllResponse(String dogName, String volunteerNickname, Str
                                    String intermediaryName, String content
 ) {
 
-    // 리뷰 이미지 리스트 필드를 제외한 생성자
+    // 후기 이미지 리스트 필드를 제외한 생성자
     public ReviewGetAllResponse(String dogName, String volunteerNickname, String mainImage,
                                 LocalDate startDate, LocalDate endDate, String departureLoc, String arrivalLoc,
                                 String intermediaryName, String content) {
         this(dogName, volunteerNickname, mainImage, null, startDate, endDate, departureLoc, arrivalLoc, intermediaryName, content);
     }
 
-    // 리뷰 이미지 리스트 필드를 포함한 생성자
+    // 후기 이미지 리스트 필드를 포함한 생성자
     public static ReviewGetAllResponse of(ReviewGetAllResponse response, List<String> images) {
         return new ReviewGetAllResponse(response.dogName, response.volunteerNickname, response.mainImage, images,
                 response.startDate, response.endDate, response.departureLoc, response.arrivalLoc, response.intermediaryName, response.content);

--- a/src/main/java/com/pawwithu/connectdog/domain/review/dto/response/ReviewGetOneResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/dto/response/ReviewGetOneResponse.java
@@ -14,14 +14,14 @@ public record ReviewGetOneResponse(String dogName, String volunteerNickname, Str
                                    String intermediaryName, String content
                                 ) {
 
-    // 리뷰 이미지 리스트 필드를 제외한 생성자
+    // 후기 이미지 리스트 필드를 제외한 생성자
     public ReviewGetOneResponse(String dogName, String volunteerNickname, String mainImage,
                                 LocalDate startDate, LocalDate endDate, String departureLoc, String arrivalLoc,
                                 String intermediaryName, String content) {
         this(dogName, volunteerNickname, mainImage, null, startDate, endDate, departureLoc, arrivalLoc, intermediaryName, content);
     }
 
-    // 리뷰 이미지 리스트 필드를 포함한 생성자
+    // 후기 이미지 리스트 필드를 함한 생성자
     public static ReviewGetOneResponse of(ReviewGetOneResponse response, List<String> images) {
         return new ReviewGetOneResponse(response.dogName, response.volunteerNickname, response.mainImage, images,
                 response.startDate, response.endDate, response.departureLoc, response.arrivalLoc, response.intermediaryName, response.content);

--- a/src/main/java/com/pawwithu/connectdog/domain/review/repository/CustomReviewRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/repository/CustomReviewRepository.java
@@ -1,5 +1,6 @@
 package com.pawwithu.connectdog.domain.review.repository;
 
+import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetReviewsResponse;
 import com.pawwithu.connectdog.domain.review.dto.response.ReviewGetAllResponse;
 import com.pawwithu.connectdog.domain.review.dto.response.ReviewGetOneResponse;
 import org.springframework.data.domain.Pageable;
@@ -8,11 +9,14 @@ import java.util.List;
 
 public interface CustomReviewRepository {
 
-    // 대표 이미지를 제외한 리뷰 이미지 조회
+    // 대표 이미지를 제외한 후기 이미지 조회
     List<String> getOneReviewImages(Long reviewId);
-    // 리뷰 단건 조회 (대표 이미지를 제외한 다른 이미지 포함 X)
+    // 후기 단건 조회 (대표 이미지를 제외한 다른 이미지 포함 X)
     ReviewGetOneResponse getOneReview(Long id, Long reviewId);
 
-    // 리뷰 전체 조회 (최신 순)
+    // 후기 전체 조회 (최신 순)
     List<ReviewGetAllResponse> getAllReviews(Pageable pageable);
+
+    // 이동봉사 중개 별 후기 조회 (최신 순)
+    List<IntermediaryGetReviewsResponse> getIntermediaryReviews(Long intermediaryId, Pageable pageable);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.pawwithu.connectdog.domain.review.repository.impl;
 
+import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetReviewsResponse;
 import com.pawwithu.connectdog.domain.review.dto.response.ReviewGetAllResponse;
 import com.pawwithu.connectdog.domain.review.dto.response.ReviewGetOneResponse;
 import com.pawwithu.connectdog.domain.review.repository.CustomReviewRepository;
@@ -26,7 +27,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    // 대표 이미지를 제외한 리뷰 이미지 조회
+    // 대표 이미지를 제외한 후기 이미지 조회
     @Override
     public List<String> getOneReviewImages(Long reviewId) {
         return queryFactory
@@ -59,13 +60,37 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
     // 후기 전체 조회
     @Override
     public List<ReviewGetAllResponse> getAllReviews(Pageable pageable) {
-        // 리뷰 정보와 함께 리뷰 ID를 조회
+        // 후기 정보와 함께 후기 ID를 조회
         List<ReviewGetAllResponse> reviews = queryFactory
                 .select(Projections.constructor(ReviewGetAllResponse.class,
                         dog.name, volunteer.nickname, reviewImage.image,
                         post.startDate, post.endDate, post.departureLoc, post.arrivalLoc,
                         intermediary.name, review.content))
                 .from(review)
+                .join(review.volunteer, volunteer)
+                .join(review.mainImage, reviewImage)
+                .join(review.post, post)
+                .join(review.post.dog, dog)
+                .join(review.post.intermediary, intermediary)
+                .orderBy(review.createdDate.desc())
+                .offset(pageable.getOffset()) // 페이지 번호
+                .limit(pageable.getPageSize()) // 페이지 사이즈
+                .fetch();
+
+        return reviews;
+    }
+
+    // 이동봉사 중개 별 후기 조회 (최신 순)
+    @Override
+    public List<IntermediaryGetReviewsResponse> getIntermediaryReviews(Long intermediaryId, Pageable pageable) {
+        // 후기 정보와 함께 후기 ID를 조회
+        List<IntermediaryGetReviewsResponse> reviews = queryFactory
+                .select(Projections.constructor(IntermediaryGetReviewsResponse.class,
+                        dog.name, volunteer.nickname, reviewImage.image,
+                        post.startDate, post.endDate, post.departureLoc, post.arrivalLoc,
+                        intermediary.name, review.content))
+                .from(review)
+                .where(review.post.intermediary.id.eq(intermediaryId))
                 .join(review.volunteer, volunteer)
                 .join(review.mainImage, reviewImage)
                 .join(review.post, post)

--- a/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
@@ -105,6 +105,8 @@ class IntermediaryControllerTest {
         images.add("image1");
         images.add("image2");
 
+        response.add(new IntermediaryGetReviewsResponse("봄이", "호짱", "mainImage", images, startDate, endDate,
+                "서울시 노원구", "서울시 성북구", "이동봉사 중개", "후기 조회 테스트입니다."));
         response.add(new IntermediaryGetReviewsResponse("겨울이", "호짱", "mainImage", images, startDate, endDate,
                 "서울시 노원구", "서울시 성북구", "이동봉사 중개", "후기 조회 테스트입니다."));
 

--- a/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
@@ -3,7 +3,9 @@ package com.pawwithu.connectdog.domain.intermediary.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetInfoResponse;
 import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetPostsResponse;
+import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetReviewsResponse;
 import com.pawwithu.connectdog.domain.intermediary.service.IntermediaryService;
+import com.pawwithu.connectdog.domain.review.dto.response.ReviewGetAllResponse;
 import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -89,6 +91,34 @@ class IntermediaryControllerTest {
         // then
         result.andExpect(status().isOk());
         verify(intermediaryService, times(1)).getIntermediaryInfo(anyLong());
+    }
+
+    @Test
+    void 이동봉사_중개_프로필_후기_조회() throws Exception {
+        // given
+        Long intermediaryId = 1L;
+        List<IntermediaryGetReviewsResponse> response = new ArrayList<>();
+        LocalDate startDate = LocalDate.of(2023, 10, 2);
+        LocalDate endDate = LocalDate.of(2023, 11, 7);
+
+        List<String> images = new ArrayList<>();
+        images.add("image1");
+        images.add("image2");
+
+        response.add(new IntermediaryGetReviewsResponse("겨울이", "호짱", "mainImage", images, startDate, endDate,
+                "서울시 노원구", "서울시 성북구", "이동봉사 중개", "후기 조회 테스트입니다."));
+
+        // when
+        given(intermediaryService.getIntermediaryReviews(anyLong(), any())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/volunteers/intermediaries/{intermediaryId}/reviews", intermediaryId)
+                        .param("page", "0")
+                        .param("size", "2")
+        );
+
+        // then
+        result.andExpect(status().isOk());
+        verify(intermediaryService, times(1)).getIntermediaryReviews(anyLong(), any());
     }
 
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/review/controller/ReviewControllerTest.java
@@ -57,7 +57,7 @@ class ReviewControllerTest {
     void 후기_등록() throws Exception {
         // given
         Long postId = 1L;
-        ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest("이동봉사 리뷰 테스트 - 봄이는 귀엽고 예쁘고 차분하다!");
+        ReviewCreateRequest reviewCreateRequest = new ReviewCreateRequest("이동봉사 후기 테스트 - 봄이는 귀엽고 예쁘고 차분하다!");
 
         MockMultipartFile files = new MockMultipartFile("files", "image1.png", "multipart/form-data", "uploadFile".getBytes(StandardCharsets.UTF_8));
         MockMultipartFile request = new MockMultipartFile("request", "", "application/json", objectMapper.registerModule(new JavaTimeModule()).writeValueAsString(reviewCreateRequest).getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
## 💡 연관된 이슈
close #83 

## 📝 작업 내용
- 이동봉사 중개 프로필 후기 조회 API 구현
- 이동봉사 중개 프로필 후기 조회 Controller 테스트 코드 추가

## 💬 리뷰 요구 사항
- 이동봉사자 후기 등록과 조회 시 사용했던 것과 달라진 점은 이동봉사 중개 id로 찾아온다는 점입니다! 이 부분 인지하고 한 번 봐주세요~!