### PR TITLE
[Feature] 이동봉사 중개 프로필 기본 정보 조회 API 응답 필드 추가

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/repository/CustomDogStatusRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/repository/CustomDogStatusRepository.java
@@ -5,7 +5,6 @@ import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetD
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface CustomDogStatusRepository {
 
@@ -16,4 +15,7 @@ public interface CustomDogStatusRepository {
 
     // 이동봉사 중개 별 근황 조회 (최신순)
     List<IntermediaryGetDogStatusesResponse> getIntermediaryDogStatuses(Long intermediaryId, Pageable pageable);
+
+    // 남긴 근황 총 건수
+    Long getCountOfDogStatuses(Long intermediaryId);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/repository/impl/CustomDogStatusRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/repository/impl/CustomDogStatusRepositoryImpl.java
@@ -11,15 +11,12 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.pawwithu.connectdog.domain.application.entity.QApplication.application;
 import static com.pawwithu.connectdog.domain.dog.entity.QDog.dog;
 import static com.pawwithu.connectdog.domain.dogStatus.entity.QDogStatusImage.dogStatusImage;
 import static com.pawwithu.connectdog.domain.dogStatus.entity.QDogStatus.dogStatus;
-import static com.pawwithu.connectdog.domain.intermediary.entity.QIntermediary.intermediary;
 import static com.pawwithu.connectdog.domain.post.entity.QPost.post;
-import static com.pawwithu.connectdog.domain.review.entity.QReview.review;
 import static com.pawwithu.connectdog.domain.volunteer.entity.QVolunteer.volunteer;
 
 @Repository
@@ -79,5 +76,15 @@ public class CustomDogStatusRepositoryImpl implements CustomDogStatusRepository 
                 .fetch();
 
         return dogStatuses;
+    }
+
+    // 남긴 근황 총 건수
+    @Override
+    public Long getCountOfDogStatuses(Long intermediaryId) {
+        return queryFactory
+                .select(dogStatus.count())
+                .from(dogStatus)
+                .where(dogStatus.intermediary.id.eq(intermediaryId))
+                .fetchOne();
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/response/IntermediaryGetInfoResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/response/IntermediaryGetInfoResponse.java
@@ -3,9 +3,10 @@ package com.pawwithu.connectdog.domain.intermediary.dto.response;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 
 public record IntermediaryGetInfoResponse(String profileImage, Long completedPostCount, String name, String intro,
-                                          String url, String contact, String guide) {
-    public static IntermediaryGetInfoResponse from(Intermediary intermediary, Long completedPostCount) {
+                                          String url, String contact, String guide,
+                                          Long reviewCount, Long dogStatusCount) {
+    public static IntermediaryGetInfoResponse from(Intermediary intermediary, Long completedPostCount, Long reviewCount, Long dogStatusCount) {
         return new IntermediaryGetInfoResponse(intermediary.getProfileImage(), completedPostCount, intermediary.getName(), intermediary.getIntro(),
-                intermediary.getUrl(), intermediary.getContact(), intermediary.getGuide());
+                intermediary.getUrl(), intermediary.getContact(), intermediary.getGuide(), reviewCount, dogStatusCount);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
@@ -46,7 +46,14 @@ public class IntermediaryService {
         Intermediary intermediary = intermediaryRepository.findById(intermediaryId).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
         // 봉사 완료 건수
         Long completedPostCount =  customPostRepository.getCountOfCompletedPosts(intermediaryId);
-        IntermediaryGetInfoResponse intermediaryInfo = IntermediaryGetInfoResponse.from(intermediary, completedPostCount);
+
+        // 받은 후기 총 건수
+        Long reviewCount = customReviewRepository.getCountOfReviews(intermediaryId);
+
+        // 남긴 근황 총 건수
+        Long dogStatusCount = customDogStatusRepository.getCountOfDogStatuses(intermediaryId);
+
+        IntermediaryGetInfoResponse intermediaryInfo = IntermediaryGetInfoResponse.from(intermediary, completedPostCount, reviewCount, dogStatusCount);
         return intermediaryInfo;
     }
 

--- a/src/main/java/com/pawwithu/connectdog/domain/review/repository/CustomReviewRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/repository/CustomReviewRepository.java
@@ -6,7 +6,6 @@ import com.pawwithu.connectdog.domain.review.dto.response.ReviewGetOneResponse;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
-import java.util.Optional;
 
 public interface CustomReviewRepository {
 
@@ -20,4 +19,7 @@ public interface CustomReviewRepository {
 
     // 이동봉사 중개 별 후기 조회 (최신 순)
     List<IntermediaryGetReviewsResponse> getIntermediaryReviews(Long intermediaryId, Pageable pageable);
+
+    // 받은 후기 총 건수
+    Long getCountOfReviews(Long intermediaryId);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
@@ -12,7 +12,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.pawwithu.connectdog.domain.intermediary.entity.QIntermediary.intermediary;
 import static com.pawwithu.connectdog.domain.post.entity.QPost.post;
@@ -101,5 +100,17 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
                 .fetch();
 
         return reviews;
+    }
+
+    // 받은 후기 총 건수
+    @Override
+    public Long getCountOfReviews(Long intermediaryId) {
+        return queryFactory
+                .select(review.count())
+                .from(review)
+                .where(review.post.intermediary.id.eq(intermediaryId))
+                .join(review.post, post)
+                .join(review.post.intermediary, intermediary)
+                .fetchOne();
     }
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
@@ -80,7 +80,7 @@ class IntermediaryControllerTest {
         // given
         Long intermediaryId = 1L;
         IntermediaryGetInfoResponse response = new IntermediaryGetInfoResponse("profileImage", 3L,
-                "이동봉사 중개 이름", "안녕하세요. 한 줄 소개 입니다.", "https://connectdog.site", "인스타그램: @hoxjeong", "안내 사항입니다.");
+                "이동봉사 중개 이름", "안녕하세요. 한 줄 소개 입니다.", "https://connectdog.site", "인스타그램: @hoxjeong", "안내 사항입니다.", 25L, 20L);
 
         // when
         given(intermediaryService.getIntermediaryInfo(anyLong())).willReturn(response);


### PR DESCRIPTION
## 💡 연관된 이슈
close #91 

## 📝 작업 내용
- 이동봉사 중개 프로필 기본 정보 조회 API 응답 필드(후기/근황 총 건수) 추가
- 이동봉사 중개 프로필 기본 정보 조회 Controller 테스트 코드 반영

## 💬 리뷰 요구 사항
후기/근황 탭에서 표시되는 총 건수가 기본 정보 조회 API에서 추가되어야 할 것 같아서 추가했습니다. 두 개의 필드 모두 카운트 쿼리가 나가는데 이 부분 한 번 봐주세요~!