### PR TITLE
[Feature] 이동봉사 중개 홈 화면 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryController.java
@@ -1,9 +1,6 @@
 package com.pawwithu.connectdog.domain.intermediary.controller;
 
-import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetDogStatusesResponse;
-import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetInfoResponse;
-import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetPostsResponse;
-import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetReviewsResponse;
+import com.pawwithu.connectdog.domain.intermediary.dto.response.*;
 import com.pawwithu.connectdog.domain.intermediary.service.IntermediaryService;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,6 +12,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -80,6 +79,19 @@ public class IntermediaryController {
     public ResponseEntity<List<IntermediaryGetDogStatusesResponse>> getIntermediaryDogStatuses(@PathVariable Long intermediaryId,
                                                                        Pageable pageable) {
         List<IntermediaryGetDogStatusesResponse> response = intermediaryService.getIntermediaryDogStatuses(intermediaryId, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "이동봉사 중개 - 홈 화면 정보 조회", description = "홈 화면 정보를 조회합니다.",
+            security = { @SecurityRequirement(name = "bearer-key") },
+            responses = {@ApiResponse(responseCode = "200", description = "이동봉사 중개 홈 화면 정보 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping("/intermediaries/home")
+    public ResponseEntity<IntermediaryGetHomeResponse> getIntermediaryHome(@AuthenticationPrincipal UserDetails loginUser) {
+        IntermediaryGetHomeResponse response = intermediaryService.getIntermediaryHome(loginUser.getUsername());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/response/IntermediaryGetHomeResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/response/IntermediaryGetHomeResponse.java
@@ -1,0 +1,13 @@
+package com.pawwithu.connectdog.domain.intermediary.dto.response;
+
+import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
+
+public record IntermediaryGetHomeResponse(String profileImage, String intermediaryName, String intro, Long recruitingCount,
+                                          Long waitingCount, Long progressingCount, Long completedCount) {
+
+    public static IntermediaryGetHomeResponse of(Intermediary intermediary, Long recruitingCount, Long waitingCount,
+                                                 Long progressingCount, Long completedCount) {
+        return new IntermediaryGetHomeResponse(intermediary.getProfileImage(), intermediary.getName(), intermediary.getIntro(),
+                recruitingCount, waitingCount, progressingCount, completedCount);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/response/IntermediaryGetHomeResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/response/IntermediaryGetHomeResponse.java
@@ -10,4 +10,5 @@ public record IntermediaryGetHomeResponse(String profileImage, String intermedia
         return new IntermediaryGetHomeResponse(intermediary.getProfileImage(), intermediary.getName(), intermediary.getIntro(),
                 recruitingCount, waitingCount, progressingCount, completedCount);
     }
+
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
@@ -1,12 +1,10 @@
 package com.pawwithu.connectdog.domain.intermediary.service;
 
 import com.pawwithu.connectdog.domain.dogStatus.repository.CustomDogStatusRepository;
-import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetDogStatusesResponse;
-import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetInfoResponse;
-import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetPostsResponse;
-import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetReviewsResponse;
+import com.pawwithu.connectdog.domain.intermediary.dto.response.*;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
+import com.pawwithu.connectdog.domain.post.entity.PostStatus;
 import com.pawwithu.connectdog.domain.post.repository.CustomPostRepository;
 import com.pawwithu.connectdog.domain.review.repository.CustomReviewRepository;
 import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
@@ -75,5 +73,15 @@ public class IntermediaryService {
         }
         List<IntermediaryGetDogStatusesResponse> intermediaryDogStatuses = customDogStatusRepository.getIntermediaryDogStatuses(intermediaryId, pageable);
         return intermediaryDogStatuses;
+    }
+
+    public IntermediaryGetHomeResponse getIntermediaryHome(String email) {
+        Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
+        Long recruitingCount = customPostRepository.getCountOfPostStatus(intermediary.getId(), PostStatus.RECRUITING);
+        Long waitingCount = customPostRepository.getCountOfPostStatus(intermediary.getId(), PostStatus.WAITING);
+        Long progressingCount = customPostRepository.getCountOfPostStatus(intermediary.getId(), PostStatus.PROGRESSING);
+        Long completedCount = customPostRepository.getCountOfPostStatus(intermediary.getId(), PostStatus.COMPLETED);
+        IntermediaryGetHomeResponse response = IntermediaryGetHomeResponse.of(intermediary, recruitingCount, waitingCount, progressingCount, completedCount);
+        return response;
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 
 import static com.pawwithu.connectdog.error.ErrorCode.INTERMEDIARY_NOT_FOUND;
 
@@ -77,11 +78,13 @@ public class IntermediaryService {
 
     public IntermediaryGetHomeResponse getIntermediaryHome(String email) {
         Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
-        Long recruitingCount = customPostRepository.getCountOfPostStatus(intermediary.getId(), PostStatus.RECRUITING);
-        Long waitingCount = customPostRepository.getCountOfPostStatus(intermediary.getId(), PostStatus.WAITING);
-        Long progressingCount = customPostRepository.getCountOfPostStatus(intermediary.getId(), PostStatus.PROGRESSING);
-        Long completedCount = customPostRepository.getCountOfPostStatus(intermediary.getId(), PostStatus.COMPLETED);
-        IntermediaryGetHomeResponse response = IntermediaryGetHomeResponse.of(intermediary, recruitingCount, waitingCount, progressingCount, completedCount);
+        Map<PostStatus, Long> countOfPostStatus = customPostRepository.getCountOfPostStatus(intermediary.getId(), null);
+        IntermediaryGetHomeResponse response = IntermediaryGetHomeResponse.of(
+                intermediary,
+                countOfPostStatus.getOrDefault(PostStatus.RECRUITING, 0L),
+                countOfPostStatus.getOrDefault(PostStatus.WAITING, 0L),
+                countOfPostStatus.getOrDefault(PostStatus.PROGRESSING, 0L),
+                countOfPostStatus.getOrDefault(PostStatus.COMPLETED, 0L));
         return response;
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
@@ -7,6 +7,7 @@ import com.pawwithu.connectdog.domain.post.entity.PostStatus;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
+import java.util.Map;
 
 public interface CustomPostRepository {
 
@@ -23,5 +24,5 @@ public interface CustomPostRepository {
     // 봉사 완료 건수
     Long getCountOfCompletedPosts(Long intermediaryId);
     PostIntermediaryGetOneResponse getIntermediaryOnePost(Long postId);
-    Long getCountOfPostStatus(Long intermediaryId, PostStatus status);
+    Map<PostStatus, Long> getCountOfPostStatus(Long intermediaryId, PostStatus status);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
@@ -3,6 +3,7 @@ package com.pawwithu.connectdog.domain.post.repository;
 import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetPostsResponse;
 import com.pawwithu.connectdog.domain.post.dto.request.PostSearchRequest;
 import com.pawwithu.connectdog.domain.post.dto.response.*;
+import com.pawwithu.connectdog.domain.post.entity.PostStatus;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -22,4 +23,5 @@ public interface CustomPostRepository {
     // 봉사 완료 건수
     Long getCountOfCompletedPosts(Long intermediaryId);
     PostIntermediaryGetOneResponse getIntermediaryOnePost(Long postId);
+    Long getCountOfPostStatus(Long intermediaryId, PostStatus status);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
@@ -141,6 +141,17 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
     }
 
     @Override
+    public Long getCountOfPostStatus(Long intermediaryId, PostStatus status) {
+        return queryFactory
+                .select(post.count())
+                .from(post)
+                .where(post.status.eq(status)
+                        .and(post.intermediary.id.eq(intermediaryId)))
+                .fetchOne();
+    }
+
+
+    @Override
     public PostIntermediaryGetOneResponse getIntermediaryOnePost(Long postId) {
         return queryFactory
                 .select(Projections.constructor(PostIntermediaryGetOneResponse.class,

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
@@ -19,6 +19,8 @@ import org.springframework.util.StringUtils;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.pawwithu.connectdog.domain.dog.entity.QDog.dog;
 import static com.pawwithu.connectdog.domain.intermediary.entity.QIntermediary.intermediary;
@@ -141,13 +143,19 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
     }
 
     @Override
-    public Long getCountOfPostStatus(Long intermediaryId, PostStatus status) {
+    public Map<PostStatus, Long> getCountOfPostStatus(Long intermediaryId, PostStatus status) {
         return queryFactory
-                .select(post.count())
+                .select(post.status, post.count())
                 .from(post)
-                .where(post.status.eq(status)
-                        .and(post.intermediary.id.eq(intermediaryId)))
-                .fetchOne();
+                .where(post.intermediary.id.eq(intermediaryId))
+                .groupBy(post.status)
+                .fetch()
+                .stream()
+                .collect(Collectors.toMap(
+                        tuple -> tuple.get(post.status),
+                        tuple -> tuple.get(post.count())
+                ));
+
     }
 
 

--- a/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
@@ -1,10 +1,7 @@
 package com.pawwithu.connectdog.domain.intermediary.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetDogStatusesResponse;
-import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetInfoResponse;
-import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetPostsResponse;
-import com.pawwithu.connectdog.domain.intermediary.dto.response.IntermediaryGetReviewsResponse;
+import com.pawwithu.connectdog.domain.intermediary.dto.response.*;
 import com.pawwithu.connectdog.domain.intermediary.service.IntermediaryService;
 import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
 import org.junit.jupiter.api.BeforeEach;
@@ -151,6 +148,23 @@ class IntermediaryControllerTest {
         // then
         result.andExpect(status().isOk());
         verify(intermediaryService, times(1)).getIntermediaryDogStatuses(anyLong(), any());
+    }
+
+    @Test
+    void 이동봉사_중개_홈_화면_정보_조회() throws Exception {
+        // given
+        IntermediaryGetHomeResponse response = new IntermediaryGetHomeResponse("image1", "하노정", "안녕하세요",
+                1L, 2L, 3L, 1L);
+
+        // when
+        given(intermediaryService.getIntermediaryHome(anyString())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/intermediaries/home")
+        );
+
+        // then
+        result.andExpect(status().isOk());
+        verify(intermediaryService, times(1)).getIntermediaryHome(anyString());
     }
 
 


### PR DESCRIPTION
## 💡 연관된 이슈
close #100 

## 📝 작업 내용
- 이동봉사 중개 홈 화면 정보 조회 API 구현
- 이동봉사 중개 홈 화면 정보 조회 Controller 테스트 코드 추가

## 💬 리뷰 요구 사항
모집중, 승인 대기중, 진행중, 봉사 완료의 수를 불러오는 데 있어 각각 쿼리가 나가는데 줄일 방법 있을지 고민입니다!
추후에 리팩토링할 때 홈 화면에 접속할 때마다 API를 불러오지 않도록 하기 위해 redis 캐싱을 이용해서 값을 저장해두는 게 좋을까요?!