### PR TITLE
[Feature] 이동봉사자 마이페이지 통계 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
@@ -17,4 +17,8 @@ public interface CustomApplicationRepository {
     List<ApplicationIntermediaryProgressingResponse> getIntermediaryProgressingApplications(Long intermediaryId, Pageable pageable);
     List<ApplicationVolunteerCompletedResponse> getVolunteerCompletedApplications(Long volunteerId, Pageable pageable);
     List<ApplicationIntermediaryCompletedResponse> getIntermediaryCompletedApplications(Long intermediaryId, Pageable pageable);
+
+    // 진행한 이동봉사 건수
+    Long getCountOfCompletedApplications(Long id);
+
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -166,4 +166,15 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
                 .limit(pageable.getPageSize())  // 페이지 사이즈
                 .fetch();
     }
+
+    // 진행한 이동봉사 건수
+    @Override
+    public Long getCountOfCompletedApplications(Long id) {
+        return queryFactory
+                .select(application.count())
+                .from(application)
+                .where(application.volunteer.id.eq(id)
+                        .and(application.status.eq(ApplicationStatus.COMPLETED)))
+                .fetchOne();
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/repository/CustomDogStatusRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/repository/CustomDogStatusRepository.java
@@ -18,5 +18,8 @@ public interface CustomDogStatusRepository {
     List<IntermediaryGetDogStatusesResponse> getIntermediaryDogStatuses(Long intermediaryId, Pageable pageable);
 
     // 남긴 근황 총 건수
-    Long getCountOfDogStatuses(Long intermediaryId);
+    Long getIntermediaryCountOfDogStatuses(Long intermediaryId);
+
+    // 입양 근황 건수
+    Long getVolunteerCountOfDogStatuses(Long id);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/dogStatus/repository/impl/CustomDogStatusRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dogStatus/repository/impl/CustomDogStatusRepositoryImpl.java
@@ -78,13 +78,25 @@ public class CustomDogStatusRepositoryImpl implements CustomDogStatusRepository 
         return dogStatuses;
     }
 
-    // 남긴 근황 총 건수
+    // 이동봉사 중개 - 남긴 근황 총 건수
     @Override
-    public Long getCountOfDogStatuses(Long intermediaryId) {
+    public Long getIntermediaryCountOfDogStatuses(Long intermediaryId) {
         return queryFactory
                 .select(dogStatus.count())
                 .from(dogStatus)
                 .where(dogStatus.intermediary.id.eq(intermediaryId))
+                .fetchOne();
+    }
+
+    // 이동봉사자 - 입양 근황 건수
+    @Override
+    public Long getVolunteerCountOfDogStatuses(Long volunteerId) {
+        return queryFactory
+                .select(dogStatus.count())
+                .from(dogStatus)
+                .join(dogStatus.post, post)
+                .join(application).on(application.post.id.eq(dogStatus.post.id))
+                .where(application.volunteer.id.eq(volunteerId))
                 .fetchOne();
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
@@ -47,10 +47,10 @@ public class IntermediaryService {
         Long completedPostCount =  customPostRepository.getCountOfCompletedPosts(intermediaryId);
 
         // 받은 후기 총 건수
-        Long reviewCount = customReviewRepository.getCountOfReviews(intermediaryId);
+        Long reviewCount = customReviewRepository.getIntermediaryCountOfReviews(intermediaryId);
 
         // 남긴 근황 총 건수
-        Long dogStatusCount = customDogStatusRepository.getCountOfDogStatuses(intermediaryId);
+        Long dogStatusCount = customDogStatusRepository.getIntermediaryCountOfDogStatuses(intermediaryId);
 
         IntermediaryGetInfoResponse intermediaryInfo = IntermediaryGetInfoResponse.from(intermediary, completedPostCount, reviewCount, dogStatusCount);
         return intermediaryInfo;

--- a/src/main/java/com/pawwithu/connectdog/domain/review/repository/CustomReviewRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/repository/CustomReviewRepository.java
@@ -22,5 +22,8 @@ public interface CustomReviewRepository {
     List<IntermediaryGetReviewsResponse> getIntermediaryReviews(Long intermediaryId, Pageable pageable);
 
     // 받은 후기 총 건수
-    Long getCountOfReviews(Long intermediaryId);
+    Long getIntermediaryCountOfReviews(Long intermediaryId);
+
+    // 봉사 후기 건수
+    Long getVolunteerCountOfReviews(Long id);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
@@ -109,7 +109,6 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
                 .select(review.count())
                 .from(review)
                 .where(review.post.intermediary.id.eq(intermediaryId))
-//                .join(review.post, post)
                 .fetchOne();
     }
 

--- a/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
@@ -102,14 +102,24 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
         return reviews;
     }
 
-    // 받은 후기 총 건수
+    // 이동봉사 중개 - 받은 후기 총 건수
     @Override
-    public Long getCountOfReviews(Long intermediaryId) {
+    public Long getIntermediaryCountOfReviews(Long intermediaryId) {
         return queryFactory
                 .select(review.count())
                 .from(review)
                 .where(review.post.intermediary.id.eq(intermediaryId))
-                .join(review.post, post)
+//                .join(review.post, post)
+                .fetchOne();
+    }
+
+    // 이동봉사자 - 남긴 봉사 후기 건수
+    @Override
+    public Long getVolunteerCountOfReviews(Long volunteerId) {
+        return queryFactory
+                .select(review.count())
+                .from(review)
+                .where(review.volunteer.id.eq(volunteerId))
                 .fetchOne();
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerController.java
@@ -1,8 +1,11 @@
 package com.pawwithu.connectdog.domain.volunteer.controller;
 
+import com.pawwithu.connectdog.domain.post.dto.request.PostSearchRequest;
+import com.pawwithu.connectdog.domain.post.dto.response.PostSearchResponse;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.AdditionalAuthRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.NicknameRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.NicknameResponse;
+import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyInfoResponse;
 import com.pawwithu.connectdog.domain.volunteer.service.VolunteerService;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -13,13 +16,13 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "Volunteer", description = "Volunteer API")
 @RestController
@@ -50,5 +53,17 @@ public class VolunteerController {
                                                @RequestBody @Valid AdditionalAuthRequest request) {
         volunteerService.additionalAuth(loginUser.getUsername(), request);
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "마이페이지 통계 정보 조회 API", description = "마이페이지 통계 정보를 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "마이페이지 통계 정보 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M1, 해당 이동봉사자를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping("/my/info")
+    public ResponseEntity<VolunteerGetMyInfoResponse> getMyInfo(@AuthenticationPrincipal UserDetails loginUser) {
+        VolunteerGetMyInfoResponse response = volunteerService.getMyInfo(loginUser.getUsername());
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/response/VolunteerGetMyInfoResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/response/VolunteerGetMyInfoResponse.java
@@ -1,0 +1,7 @@
+package com.pawwithu.connectdog.domain.volunteer.dto.response;
+
+public record VolunteerGetMyInfoResponse(Long completedCount, Long reviewCount, Long dogStatusCount) {
+    public static VolunteerGetMyInfoResponse of(Long completedCount, Long reviewCount, Long dogStatusCount) {
+        return new VolunteerGetMyInfoResponse(completedCount, reviewCount, dogStatusCount);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/service/VolunteerService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/service/VolunteerService.java
@@ -1,8 +1,12 @@
 package com.pawwithu.connectdog.domain.volunteer.service;
 
+import com.pawwithu.connectdog.domain.application.repository.CustomApplicationRepository;
+import com.pawwithu.connectdog.domain.dogStatus.repository.CustomDogStatusRepository;
+import com.pawwithu.connectdog.domain.review.repository.CustomReviewRepository;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.AdditionalAuthRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.NicknameRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.NicknameResponse;
+import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyInfoResponse;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import com.pawwithu.connectdog.domain.volunteer.repository.VolunteerRepository;
 import com.pawwithu.connectdog.error.ErrorCode;
@@ -12,6 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.pawwithu.connectdog.error.ErrorCode.VOLUNTEER_NOT_FOUND;
+
 @Slf4j
 @Service
 @Transactional
@@ -19,6 +25,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class VolunteerService {
 
     private final VolunteerRepository volunteerRepository;
+    private final CustomApplicationRepository customApplicationRepository;
+    private final CustomReviewRepository customReviewRepository;
+    private final CustomDogStatusRepository customDogStatusRepository;
 
     @Transactional(readOnly = true)
     public NicknameResponse isNicknameDuplicated(NicknameRequest nickNameRequest) {
@@ -30,5 +39,22 @@ public class VolunteerService {
     public void additionalAuth(String email, AdditionalAuthRequest request) {
         Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(ErrorCode.VOLUNTEER_NOT_FOUND));
         volunteer.updateNameAndPhone(request.name(), request.phone());
+    }
+
+    @Transactional(readOnly = true)
+    public VolunteerGetMyInfoResponse getMyInfo(String email) {
+        Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
+
+        // 진행한 이동봉사 건수
+        Long completedCount = customApplicationRepository.getCountOfCompletedApplications(volunteer.getId());
+
+        // 봉사 후기 건수
+        Long reviewCount = customReviewRepository.getVolunteerCountOfReviews(volunteer.getId());
+
+        // 입양 근황 건수
+        Long dogStatusCount = customDogStatusRepository.getVolunteerCountOfDogStatuses(volunteer.getId());
+
+        VolunteerGetMyInfoResponse response = VolunteerGetMyInfoResponse.of(completedCount, reviewCount, dogStatusCount);
+        return response;
     }
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.AdditionalAuthRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.NicknameRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.NicknameResponse;
+import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyInfoResponse;
 import com.pawwithu.connectdog.domain.volunteer.service.VolunteerService;
 import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
 import org.junit.jupiter.api.BeforeEach;
@@ -18,11 +19,11 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.filter.CharacterEncodingFilter;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -80,4 +81,22 @@ class VolunteerControllerTest {
         result.andExpect(status().isNoContent());
         verify(volunteerService, times(1)).additionalAuth(anyString(), any());
     }
+
+    @Test
+    void 이동봉사자_마이페이지_통계_정보_조회() throws Exception {
+        // given
+        Long volunteerId = 1L;
+        VolunteerGetMyInfoResponse response = VolunteerGetMyInfoResponse.of(1L, 3L, 5L);
+
+        // when
+        given(volunteerService.getMyInfo(any())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/volunteers/my/info")
+        );
+
+        // then
+        result.andExpect(status().isOk());
+        verify(volunteerService, times(1)).getMyInfo(any());
+    }
+
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #99 

## 📝 작업 내용
- 이동봉사자 마이페이지 통계 정보 조회 API 구현
- 이동봉사자 마이페이지 통계 정보 조회 Controller 테스트 코드 추가

## 💬 리뷰 요구 사항
이전 카운트 쿼리도 살짝 수정했습니다! 불필요한 조인을 제거했어요 :)