### PR TITLE
[Feature] 이동봉사자 마이페이지 북마크한 공고 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/bookmark/controller/BookmarkController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/bookmark/controller/BookmarkController.java
@@ -31,7 +31,7 @@ public class BookmarkController {
                     , description = "M2, 해당 이동봉사자를 찾을 수 없습니다. \t\n P2, 해당 공고를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
-    @PostMapping(value = "/volunteers/bookmarks/{postId}")
+    @PostMapping(value = "/volunteers/posts/{postId}/bookmarks")
     public ResponseEntity<Void> createBookmark(@AuthenticationPrincipal UserDetails loginUser, @PathVariable("postId") Long postId) {
         bookmarkService.createBookmark(loginUser.getUsername(), postId);
         return ResponseEntity.noContent().build();
@@ -44,7 +44,7 @@ public class BookmarkController {
                     , description = "M2, 해당 이동봉사자를 찾을 수 없습니다. \t\n P2, 해당 공고를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
-    @DeleteMapping(value = "/volunteers/bookmarks/{postId}")
+    @DeleteMapping(value = "/volunteers/posts/{postId}/bookmarks")
     public ResponseEntity<Void> deleteBookmark(@AuthenticationPrincipal UserDetails loginUser, @PathVariable("postId") Long postId) {
         bookmarkService.deleteBookmark(loginUser.getUsername(), postId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/pawwithu/connectdog/domain/bookmark/repository/CustomBookmarkRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/bookmark/repository/CustomBookmarkRepository.java
@@ -1,0 +1,9 @@
+package com.pawwithu.connectdog.domain.bookmark.repository;
+
+import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyBookmarkResponse;
+
+import java.util.List;
+
+public interface CustomBookmarkRepository {
+    List<VolunteerGetMyBookmarkResponse> getMyBookmarks(Long volunteerId);
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/bookmark/repository/CustomBookmarkRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/bookmark/repository/CustomBookmarkRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.pawwithu.connectdog.domain.bookmark.repository;
+
+import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyBookmarkResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.pawwithu.connectdog.domain.bookmark.entity.QBookmark.bookmark;
+import static com.pawwithu.connectdog.domain.intermediary.entity.QIntermediary.intermediary;
+import static com.pawwithu.connectdog.domain.post.entity.QPost.post;
+import static com.pawwithu.connectdog.domain.post.entity.QPostImage.postImage;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class CustomBookmarkRepositoryImpl implements CustomBookmarkRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<VolunteerGetMyBookmarkResponse> getMyBookmarks(Long volunteerId) {
+        return queryFactory
+                .select(Projections.constructor(VolunteerGetMyBookmarkResponse.class,
+                        post.id, postImage.image, post.departureLoc, post.arrivalLoc, post.startDate, post.endDate,
+                        intermediary.name, post.isKennel))
+                .from(post)
+                .join(post.mainImage, postImage)
+                .join(bookmark).on(bookmark.post.id.eq(post.id))
+                .where(bookmark.volunteer.id.eq(volunteerId))
+                .fetch();
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerController.java
@@ -1,10 +1,9 @@
 package com.pawwithu.connectdog.domain.volunteer.controller;
 
-import com.pawwithu.connectdog.domain.post.dto.request.PostSearchRequest;
-import com.pawwithu.connectdog.domain.post.dto.response.PostSearchResponse;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.AdditionalAuthRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.NicknameRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.NicknameResponse;
+import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyBookmarkResponse;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyInfoResponse;
 import com.pawwithu.connectdog.domain.volunteer.service.VolunteerService;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
@@ -16,7 +15,6 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -64,6 +62,18 @@ public class VolunteerController {
     @GetMapping("/my/info")
     public ResponseEntity<VolunteerGetMyInfoResponse> getMyInfo(@AuthenticationPrincipal UserDetails loginUser) {
         VolunteerGetMyInfoResponse response = volunteerService.getMyInfo(loginUser.getUsername());
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "마이페이지 북마크한 공고 목록 조회 API", description = "마이페이지 북마크한 공고 목록을 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "마이페이지 북마크한 공고 목록 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M1, 해당 이동봉사자를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping("/my/bookmarks")
+    public ResponseEntity<List<VolunteerGetMyBookmarkResponse>> getMyBookmarks(@AuthenticationPrincipal UserDetails loginUser) {
+        List<VolunteerGetMyBookmarkResponse> response = volunteerService.getMyBookmarks(loginUser.getUsername());
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/response/VolunteerGetMyBookmarkResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/response/VolunteerGetMyBookmarkResponse.java
@@ -1,0 +1,14 @@
+package com.pawwithu.connectdog.domain.volunteer.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+
+import java.time.LocalDate;
+
+public record VolunteerGetMyBookmarkResponse(Long postId, String mainImage, String departureLoc, String arrivalLoc,
+                                             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                             LocalDate startDate,
+                                             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+                                             LocalDate endDate,
+                                             String intermediaryName,
+                                             Boolean isKennel) {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/service/VolunteerService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/service/VolunteerService.java
@@ -1,11 +1,13 @@
 package com.pawwithu.connectdog.domain.volunteer.service;
 
 import com.pawwithu.connectdog.domain.application.repository.CustomApplicationRepository;
+import com.pawwithu.connectdog.domain.bookmark.repository.CustomBookmarkRepository;
 import com.pawwithu.connectdog.domain.dogStatus.repository.CustomDogStatusRepository;
 import com.pawwithu.connectdog.domain.review.repository.CustomReviewRepository;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.AdditionalAuthRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.NicknameRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.NicknameResponse;
+import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyBookmarkResponse;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyInfoResponse;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import com.pawwithu.connectdog.domain.volunteer.repository.VolunteerRepository;
@@ -15,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 import static com.pawwithu.connectdog.error.ErrorCode.VOLUNTEER_NOT_FOUND;
 
@@ -28,6 +32,7 @@ public class VolunteerService {
     private final CustomApplicationRepository customApplicationRepository;
     private final CustomReviewRepository customReviewRepository;
     private final CustomDogStatusRepository customDogStatusRepository;
+    private final CustomBookmarkRepository customBookmarkRepository;
 
     @Transactional(readOnly = true)
     public NicknameResponse isNicknameDuplicated(NicknameRequest nickNameRequest) {
@@ -56,5 +61,13 @@ public class VolunteerService {
 
         VolunteerGetMyInfoResponse response = VolunteerGetMyInfoResponse.of(completedCount, reviewCount, dogStatusCount);
         return response;
+    }
+
+    @Transactional(readOnly = true)
+    public List<VolunteerGetMyBookmarkResponse> getMyBookmarks(String email) {
+        Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
+
+        List<VolunteerGetMyBookmarkResponse> bookmarks = customBookmarkRepository.getMyBookmarks(volunteer.getId());
+        return bookmarks;
     }
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerControllerTest.java
@@ -1,9 +1,11 @@
 package com.pawwithu.connectdog.domain.volunteer.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.AdditionalAuthRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.NicknameRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.NicknameResponse;
+import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyBookmarkResponse;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyInfoResponse;
 import com.pawwithu.connectdog.domain.volunteer.service.VolunteerService;
 import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
@@ -18,6 +20,10 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
@@ -85,7 +91,6 @@ class VolunteerControllerTest {
     @Test
     void 이동봉사자_마이페이지_통계_정보_조회() throws Exception {
         // given
-        Long volunteerId = 1L;
         VolunteerGetMyInfoResponse response = VolunteerGetMyInfoResponse.of(1L, 3L, 5L);
 
         // when
@@ -99,4 +104,25 @@ class VolunteerControllerTest {
         verify(volunteerService, times(1)).getMyInfo(any());
     }
 
+    @Test
+    void 이동봉사자_마이페이지_북마크한_공고_목록_조회() throws Exception {
+        // given
+        List<VolunteerGetMyBookmarkResponse> response = new ArrayList<>();
+        LocalDate startDate = LocalDate.of(2023, 10, 2);
+        LocalDate endDate = LocalDate.of(2023, 11, 7);
+        response.add(new VolunteerGetMyBookmarkResponse(1L, "image1", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "이동봉사 중개", true));
+        response.add(new VolunteerGetMyBookmarkResponse(2L, "image2", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "이동봉사 중개", false));
+
+        // when
+        given(volunteerService.getMyBookmarks(any())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/volunteers/my/bookmarks")
+        );
+
+        // then
+        result.andExpect(status().isOk());
+        verify(volunteerService, times(1)).getMyBookmarks(any());
+    }
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #105 

## 📝 작업 내용
- 이동봉사자 마이페이지 북마크한 공고 목록 조회 API 구현
- 이동봉사자 마이페이지 북마크한 공고 목록 Controller 테스트 코드 추가
- 이동봉사자 북마크 등록/삭제 uri 변경

## 💬 리뷰 요구 사항
홈 화면 공고 목록 조회 API 참고했습니다!
