### PR TITLE
[Feature] 이동봉사 중개 봉사 완료 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
@@ -198,4 +198,17 @@ public class ApplicationController {
         ApplicationVolunteerInfoResponse response = applicationService.getMyInfo(loginUser.getUsername());
         return ResponseEntity.ok(response);
     }
+
+    @Operation(summary = "봉사 관리 - 진행중 - 봉사 완료하기", description = "진행중인 봉사를 완료합니다.",
+            responses = {@ApiResponse(responseCode = "204", description = "봉사 신청 확정 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다. \t\n AP2, 해당 신청 내역을 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @PatchMapping( "/intermediaries/applications/{applicationId}/completed")
+    public ResponseEntity<Void> completeApplication(@AuthenticationPrincipal UserDetails loginUser,
+                                                   @PathVariable Long applicationId) {
+        applicationService.completeApplication(loginUser.getUsername(), applicationId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
@@ -2,6 +2,7 @@ package com.pawwithu.connectdog.domain.application.repository;
 
 import com.pawwithu.connectdog.domain.application.dto.response.*;
 import com.pawwithu.connectdog.domain.application.entity.Application;
+import com.pawwithu.connectdog.domain.application.entity.ApplicationStatus;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -12,7 +13,7 @@ public interface CustomApplicationRepository {
     List<ApplicationVolunteerWaitingResponse> getVolunteerWaitingApplications(Long volunteerId, Pageable pageable);
     List<ApplicationVolunteerProgressingResponse> getVolunteerProgressingApplications(Long volunteerId, Pageable pageable);
     Optional<Application> findByIdAndVolunteerIdWithPost(Long applicationId, Long volunteerId);
-    Optional<Application> findByIdAndIntermediaryIdWithPost(Long applicationId, Long intermediaryId);
+    Optional<Application> findByIdAndIntermediaryIdAndStatusWithPost(Long applicationId, Long intermediaryId, ApplicationStatus status);
     List<ApplicationIntermediaryWaitingResponse> getIntermediaryWaitingApplications(Long intermediaryId, Pageable pageable);
     List<ApplicationIntermediaryProgressingResponse> getIntermediaryProgressingApplications(Long intermediaryId, Pageable pageable);
     List<ApplicationVolunteerCompletedResponse> getVolunteerCompletedApplications(Long volunteerId, Pageable pageable);

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -78,14 +78,14 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
     }
 
     @Override
-    public Optional<Application> findByIdAndIntermediaryIdWithPost(Long applicationId, Long intermediaryId) {
+    public Optional<Application> findByIdAndIntermediaryIdAndStatusWithPost(Long applicationId, Long intermediaryId, ApplicationStatus status) {
         return Optional.ofNullable(queryFactory
                 .select(application)
                 .from(application)
                 .join(application.post, post).fetchJoin()
                 .where(application.id.eq(applicationId)
                         .and(application.intermediary.id.eq(intermediaryId))
-                        .and(application.status.eq(ApplicationStatus.WAITING)))
+                        .and(application.status.eq(status)))
                 .fetchOne());
     }
 

--- a/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
@@ -169,4 +169,15 @@ public class ApplicationService {
         ApplicationVolunteerInfoResponse volunteerInfo = ApplicationVolunteerInfoResponse.of(volunteer.getName(), volunteer.getPhone());
         return volunteerInfo;
     }
+
+    public void completeApplication(String email, Long applicationId) {
+        // 이동봉사 중개
+        Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
+        // 신청 내역 + post
+        Application application = customApplicationRepository.findByIdAndIntermediaryIdAndStatusWithPost(applicationId, intermediary.getId(), ApplicationStatus.PROGRESSING).orElseThrow(() -> new BadRequestException(APPLICATION_NOT_FOUND));
+        Post post = application.getPost();
+        // 상태 업데이트 (진행중 -> 봉사 완료)
+        application.updateStatus(ApplicationStatus.COMPLETED);
+        post.updateStatus(PostStatus.COMPLETED);
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
@@ -102,7 +102,7 @@ public class ApplicationService {
         // 이동봉사 중개
         Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
         // 신청 내역 + post
-        Application application = customApplicationRepository.findByIdAndIntermediaryIdWithPost(applicationId, intermediary.getId()).orElseThrow(() -> new BadRequestException(APPLICATION_NOT_FOUND));
+        Application application = customApplicationRepository.findByIdAndIntermediaryIdAndStatusWithPost(applicationId, intermediary.getId(), ApplicationStatus.WAITING).orElseThrow(() -> new BadRequestException(APPLICATION_NOT_FOUND));
         Post post = application.getPost();
         // 상태 업데이트 (승인 대기중 -> 진행중)
         application.updateStatus(ApplicationStatus.PROGRESSING);
@@ -113,7 +113,7 @@ public class ApplicationService {
         // 이동봉사 중개
         Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
         // 신청 내역 + post
-        Application application = customApplicationRepository.findByIdAndIntermediaryIdWithPost(applicationId, intermediary.getId()).orElseThrow(() -> new BadRequestException(APPLICATION_NOT_FOUND));
+        Application application = customApplicationRepository.findByIdAndIntermediaryIdAndStatusWithPost(applicationId, intermediary.getId(), ApplicationStatus.WAITING).orElseThrow(() -> new BadRequestException(APPLICATION_NOT_FOUND));
         applicationRepository.delete(application);
         // 상태 업데이트 (승인 대기중 -> 모집중)
         Post post = application.getPost();
@@ -162,6 +162,7 @@ public class ApplicationService {
         return oneApplication;
     }
 
+    @Transactional(readOnly = true)
     public ApplicationVolunteerInfoResponse getMyInfo(String email) {
         // 이동봉사자
         Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));

--- a/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
@@ -303,4 +303,19 @@ class ApplicationControllerTest {
         verify(applicationService, times(1)).getMyInfo(anyString());
     }
 
+    @Test
+    void 이동봉사_완료() throws Exception {
+        //given
+        Long applicationId = 1L;
+
+        //when
+        ResultActions result = mockMvc.perform(
+                patch("/intermediaries/applications/{applicationId}/completed", applicationId)
+        );
+
+        //then
+        result.andExpect(status().isNoContent());
+        verify(applicationService, times(1)).completeApplication(anyString(), anyLong());
+    }
+
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #112 

## 📝 작업 내용
- 신청 내역 가져오는 쿼리 Application 상태 조건 추가, 적용
- 이동봉사 중개 봉사 완료 API 구현
- 이동봉사 중개 봉사 완료 Controller 테스트 코드 추가

## 💬 리뷰 요구 사항
신청 내역 가져오는 쿼리가 이전에는 승인 대기중인 신청만 가져오는 걸로 되어 있었는데, 이번에 작업한 API에서는 진행중인 내역을 가져와야 했습니다!
따라서 신청 내역 가져오는 쿼리에서 상태 조건을 추가해 이번에 작업하는 API에서도 해당 메서드를 사용할 수 있도록 했습니다!
