### PR TITLE
[Feature] 이동봉사자 마이페이지 활동 배지 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/config/SwaggerConfig.java
+++ b/src/main/java/com/pawwithu/connectdog/config/SwaggerConfig.java
@@ -1,0 +1,38 @@
+package com.pawwithu.connectdog.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.utils.SpringDocUtils;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearer-key",
+                                new SecurityScheme().type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")))
+                .info(apiInfo());
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("ConnectDog API")
+                .description("ConnectDog API 문서")
+                .version("1.0.0");
+    }
+
+    static {
+        var schema = new Schema<LocalTime>();
+        schema.example(LocalTime.now().format(DateTimeFormatter.ofPattern("HH:mm:ss"))).type("string");
+        SpringDocUtils.getConfig().replaceWithSchema(LocalTime.class, schema);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/badge/entity/Badge.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/badge/entity/Badge.java
@@ -18,5 +18,7 @@ public class Badge extends BaseTimeEntity {
     private Long id;
     @Column(length = 20, nullable = false)
     private String name; // 뱃지 이름
+    @Column(nullable = false)
+    private String image; // 뱃지 사진
 
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/badge/repository/CustomVolunteerBadgeRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/badge/repository/CustomVolunteerBadgeRepository.java
@@ -1,0 +1,9 @@
+package com.pawwithu.connectdog.domain.badge.repository;
+
+import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyBadgeResponse;
+
+import java.util.List;
+
+public interface CustomVolunteerBadgeRepository {
+    List<VolunteerGetMyBadgeResponse> getMyBadges(Long id);
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/badge/repository/impl/CustomVolunteerBadgeRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/badge/repository/impl/CustomVolunteerBadgeRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.pawwithu.connectdog.domain.badge.repository.impl;
+
+import com.pawwithu.connectdog.domain.badge.repository.CustomVolunteerBadgeRepository;
+import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyBadgeResponse;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.pawwithu.connectdog.domain.badge.entity.QBadge.badge;
+import static com.pawwithu.connectdog.domain.badge.entity.QVolunteerBadge.volunteerBadge;
+
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class CustomVolunteerBadgeRepositoryImpl implements CustomVolunteerBadgeRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<VolunteerGetMyBadgeResponse> getMyBadges(Long volunteerId) {
+        return queryFactory
+                .select(Projections.constructor(VolunteerGetMyBadgeResponse.class,
+                        badge.id,
+                        badge.name,
+                        new CaseBuilder()
+                                .when(volunteerBadge.id.isNotNull())
+                                .then(badge.image)
+                                .otherwise((String) null)))
+                .from(badge)
+                .leftJoin(volunteerBadge)
+                .on(volunteerBadge.badge.id.eq(badge.id)
+                        .and(volunteerBadge.volunteer.id.eq(volunteerId)))
+                .fetch();
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerController.java
@@ -3,6 +3,7 @@ package com.pawwithu.connectdog.domain.volunteer.controller;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.AdditionalAuthRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.NicknameRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.NicknameResponse;
+import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyBadgeResponse;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyBookmarkResponse;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyInfoResponse;
 import com.pawwithu.connectdog.domain.volunteer.service.VolunteerService;
@@ -76,4 +77,18 @@ public class VolunteerController {
         List<VolunteerGetMyBookmarkResponse> response = volunteerService.getMyBookmarks(loginUser.getUsername());
         return ResponseEntity.ok(response);
     }
+
+    @Operation(summary = "마이페이지 활동 배지 목록 조회 API", description = "마이페이지 활동 배지 목록을 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "마이페이지 활동 배지 목록 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M1, 해당 이동봉사자를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping("/my/badges")
+    public ResponseEntity<List<VolunteerGetMyBadgeResponse>> getMyBadges(@AuthenticationPrincipal UserDetails loginUser) {
+        List<VolunteerGetMyBadgeResponse> response = volunteerService.getMyBadges(loginUser.getUsername());
+        return ResponseEntity.ok(response);
+    }
+
+
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/response/VolunteerGetMyBadgeResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/response/VolunteerGetMyBadgeResponse.java
@@ -1,0 +1,4 @@
+package com.pawwithu.connectdog.domain.volunteer.dto.response;
+
+public record VolunteerGetMyBadgeResponse(Long badgeId, String name, String image) {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/service/VolunteerService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/service/VolunteerService.java
@@ -1,12 +1,14 @@
 package com.pawwithu.connectdog.domain.volunteer.service;
 
 import com.pawwithu.connectdog.domain.application.repository.CustomApplicationRepository;
+import com.pawwithu.connectdog.domain.badge.repository.CustomVolunteerBadgeRepository;
 import com.pawwithu.connectdog.domain.bookmark.repository.CustomBookmarkRepository;
 import com.pawwithu.connectdog.domain.dogStatus.repository.CustomDogStatusRepository;
 import com.pawwithu.connectdog.domain.review.repository.CustomReviewRepository;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.AdditionalAuthRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.NicknameRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.NicknameResponse;
+import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyBadgeResponse;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyBookmarkResponse;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyInfoResponse;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
@@ -33,6 +35,7 @@ public class VolunteerService {
     private final CustomReviewRepository customReviewRepository;
     private final CustomDogStatusRepository customDogStatusRepository;
     private final CustomBookmarkRepository customBookmarkRepository;
+    private final CustomVolunteerBadgeRepository customVolunteerBadgeRepository;
 
     @Transactional(readOnly = true)
     public NicknameResponse isNicknameDuplicated(NicknameRequest nickNameRequest) {
@@ -69,5 +72,13 @@ public class VolunteerService {
 
         List<VolunteerGetMyBookmarkResponse> bookmarks = customBookmarkRepository.getMyBookmarks(volunteer.getId());
         return bookmarks;
+    }
+
+    @Transactional(readOnly = true)
+    public List<VolunteerGetMyBadgeResponse> getMyBadges(String email) {
+        Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
+
+        List<VolunteerGetMyBadgeResponse> badges = customVolunteerBadgeRepository.getMyBadges(volunteer.getId());
+        return badges;
     }
 }

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -41,3 +41,21 @@ UPDATE post SET main_image_id = 12 WHERE id = 6;
 INSERT INTO application (id, status, volunteer_name, phone, transportation, content, post_id, intermediary_id, volunteer_id, created_date, modified_date) VALUES (1, 0, '한호정', '01022223333', 'BMW', '이동봉사 신청합니다!', 3, 1, 1,now(), now());
 INSERT INTO application (id, status, volunteer_name, phone, transportation, content, post_id, intermediary_id, volunteer_id, created_date, modified_date) VALUES (2, 1, '한호정', '01022223333', 'BMW', '이동봉사 신청합니다!', 4, 1, 1,now(), now());
 INSERT INTO application (id, status, volunteer_name, phone, transportation, content, post_id, intermediary_id, volunteer_id, created_date, modified_date) VALUES (3, 2, '한호정', '01022223333', 'BMW', '이동봉사 신청합니다!', 5, 1, 1,now(), now());
+-- INSERT BADGE
+INSERT INTO badge (id, name, image, created_date, modified_date) VALUES (1, '첫 연결의 설렘\n1마리 연결', 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/badge/badge1.png', now(), now());
+INSERT INTO badge (id, name, image, created_date, modified_date) VALUES (2, '초심자의 열정\n3마리 연결', 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/badge/badge2.png', now(), now());
+INSERT INTO badge (id, name, image, created_date, modified_date) VALUES (3, '소중함을 아니까\n5마리 연결', 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/badge/badge3.png', now(), now());
+INSERT INTO badge (id, name, image, created_date, modified_date) VALUES (4, '신뢰의 시작\n10마리 연결', 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/badge/badge0.png', now(), now());
+INSERT INTO badge (id, name, image, created_date, modified_date) VALUES (5, '열정 봉사자\n20마리 연결', 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/badge/badge0.png', now(), now());
+INSERT INTO badge (id, name, image, created_date, modified_date) VALUES (6, '이동봉사 마스터\n30마리 연결', 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/badge/badge0.png', now(), now());
+INSERT INTO badge (id, name, image, created_date, modified_date) VALUES (7, '첫 기록의 뿌듯함\n1개 등록', 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/badge/badge7.png', now(), now());
+INSERT INTO badge (id, name, image, created_date, modified_date) VALUES (8, '제법 쓸 줄 알아요\n3개 등록', 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/badge/badge0.png', now(), now());
+INSERT INTO badge (id, name, image, created_date, modified_date) VALUES (9, '봉사 꿀팁 보유자\n5개 등록', 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/badge/badge0.png', now(), now());
+INSERT INTO badge (id, name, image, created_date, modified_date) VALUES (10, '믿음직한 후기\n10개 등록', 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/badge/badge0.png', now(), now());
+INSERT INTO badge (id, name, image, created_date, modified_date) VALUES (11, '성실 기록가\n20개 등록', 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/badge/badge0.png', now(), now());
+INSERT INTO badge (id, name, image, created_date, modified_date) VALUES (12, '코넥독 후기왕\n30개 등록', 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/badge/badge0.png', now(), now());
+-- INSERT VOLUNTEER_BADGE
+INSERT INTO volunteer_badge(id, badge_id, volunteer_id, created_date, modified_date) VALUES (1, 1, 1, now(), now());
+INSERT INTO volunteer_badge(id, badge_id, volunteer_id, created_date, modified_date) VALUES (2, 2, 1, now(), now());
+INSERT INTO volunteer_badge(id, badge_id, volunteer_id, created_date, modified_date) VALUES (3, 3, 1, now(), now());
+INSERT INTO volunteer_badge(id, badge_id, volunteer_id, created_date, modified_date) VALUES (7, 7, 1, now(), now());

--- a/src/test/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerControllerTest.java
@@ -5,6 +5,7 @@ import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.AdditionalAuthRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.request.NicknameRequest;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.NicknameResponse;
+import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyBadgeResponse;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyBookmarkResponse;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerGetMyInfoResponse;
 import com.pawwithu.connectdog.domain.volunteer.service.VolunteerService;
@@ -124,5 +125,24 @@ class VolunteerControllerTest {
         // then
         result.andExpect(status().isOk());
         verify(volunteerService, times(1)).getMyBookmarks(any());
+    }
+
+    @Test
+    void 이동봉사자_마이페이지_활동_배지_목록_조회() throws Exception {
+        // given
+        List<VolunteerGetMyBadgeResponse> response = new ArrayList<>();
+        response.add(new VolunteerGetMyBadgeResponse(1L, "코넥독 후기왕1", "image1"));
+        response.add(new VolunteerGetMyBadgeResponse(2L, "코넥독 후기왕2", "image2"));
+        response.add(new VolunteerGetMyBadgeResponse(2L, "코넥독 후기왕3", null));
+
+        // when
+        given(volunteerService.getMyBadges(any())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/volunteers/my/badges")
+        );
+
+        // then
+        result.andExpect(status().isOk());
+        verify(volunteerService, times(1)).getMyBadges(any());
     }
 }


### PR DESCRIPTION
## 💡 연관된 이슈
close #111 

## 📝 작업 내용
- 이동봉사자 마이페이지 활동 배지 목록 조회 API 구현
- 이동봉사자 마이페이지 활동 배지 목록 조회 Controller 테스트 코드 추가
- SwaggerConfig 추가

## 💬 리뷰 요구 사항
꽤 많은 시간 고민을 한 API입니다. 응답 Dto는 항상 사이즈 12이며, 이동봉사자가 획득한 배지는 이미지 url을 담고 아닌 배지는 null로 반환합니다. 쿼리 나가는 부분에서 leftJoin, CaseBuilder를 사용한 부분 한 번 봐주세요~!

Badge 더미 데이터에는 현재 아직 디자인 작업이 안 된 배지들은 0번으로 넣어놨습니다. 