### PR TITLE
[Feature] Firebase 설정 및 푸시 알림 구현

### DIFF
--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -53,7 +53,7 @@ jobs:
       # firebase-key.json 생성
       - name: create firebase-key.json
         run: |
-          cd ./src/main/resources/firebase
+          cd ./src/main/resources
           touch ./firebase-key.json
           echo "${{ secrets.FCM }}" | base64 --decode > ./firebase-key.json
           ls -la

--- a/.github/workflows/dev-deploy.yml
+++ b/.github/workflows/dev-deploy.yml
@@ -50,6 +50,15 @@ jobs:
           echo "${{ secrets.APPLICATION_DEV_YML }}" > ./application-dev.yml
         shell: bash
 
+      # firebase-key.json 생성
+      - name: create firebase-key.json
+        run: |
+          cd ./src/main/resources/firebase
+          touch ./firebase-key.json
+          echo "${{ secrets.FCM }}" | base64 --decode > ./firebase-key.json
+          ls -la
+        shell: bash
+
       # ./gradlew 권한 설정
       - name: ./gradlew 권한 설정
         run: chmod +x ./gradlew

--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,4 @@ application-prod.yml
 application-oauth.yml
 application-jwt.yml
 
-src/main/resources/firebase/firebase-key.json
+src/main/resources/firebase-key.json

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,5 @@ application-dev.yml
 application-prod.yml
 application-oauth.yml
 application-jwt.yml
+
+src/main/resources/firebase/firebase-key.json

--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
 	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	// firebase
+	implementation 'com.google.firebase:firebase-admin:6.8.1'
+	implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.2.2'
 }
 
 // Querydsl 설정부

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/controller/FcmController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/controller/FcmController.java
@@ -1,0 +1,55 @@
+package com.pawwithu.connectdog.domain.fcm.controller;
+
+import com.pawwithu.connectdog.domain.fcm.dto.request.IntermediaryFcmRequest;
+import com.pawwithu.connectdog.domain.fcm.dto.request.VolunteerFcmRequest;
+import com.pawwithu.connectdog.domain.fcm.service.FcmService;
+import com.pawwithu.connectdog.error.dto.ErrorResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Fcm", description = "Fcm API")
+@RestController
+@RequiredArgsConstructor
+public class FcmController {
+
+    private final FcmService fcmService;
+
+    @Operation(summary = "이동봉사자 - FCM 토큰 저장", description = "이동봉사자의 FCM 토큰을 저장합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "FCM 토큰 저장 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "V1, fcm 토큰은 필수 입력 값입니다. \t\n M1, 해당 이동봉사자를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @PostMapping("/volunteers/fcm")
+    public ResponseEntity<Void> saveVolunteerFcm(@AuthenticationPrincipal UserDetails loginUser,
+                                        @Valid @RequestBody VolunteerFcmRequest request) {
+
+        fcmService.saveVolunteerFcm(loginUser.getUsername(), request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "이동봉사 중개 - FCM 토큰 저장", description = "이동봉사 중개의 FCM 토큰을 저장합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "FCM 토큰 저장 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "V1, fcm 토큰은 필수 입력 값입니다. \t\n M2, 해당 이동봉사 중개를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @PostMapping("/intermediaries/fcm")
+    public ResponseEntity<Void> saveIntermediaryFcm(@AuthenticationPrincipal UserDetails loginUser,
+                                        @Valid @RequestBody IntermediaryFcmRequest request) {
+
+        fcmService.saveIntermediaryFcm(loginUser.getUsername(), request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/request/FcmMessage.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/request/FcmMessage.java
@@ -1,0 +1,32 @@
+package com.pawwithu.connectdog.domain.fcm.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class FcmMessage {
+
+    private boolean validateOnly;
+    private Message message;
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Message {
+        private Notification notification;
+        private String token;
+
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class Notification {
+        private String title;
+        private String body;
+    }
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/request/IntermediaryFcmRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/request/IntermediaryFcmRequest.java
@@ -1,0 +1,16 @@
+package com.pawwithu.connectdog.domain.fcm.dto.request;
+
+import com.pawwithu.connectdog.domain.fcm.entity.IntermediaryFcm;
+import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
+import jakarta.validation.constraints.NotBlank;
+
+public record IntermediaryFcmRequest(@NotBlank(message = "fcm 토큰은 필수 입력 값입니다.")
+                                     String fcmToken) {
+
+    public static IntermediaryFcm IntermediaryToEntity(Intermediary intermediary, IntermediaryFcmRequest request) {
+        return IntermediaryFcm.builder()
+                .intermediary(intermediary)
+                .fcmToken(request.fcmToken)
+                .build();
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/request/VolunteerFcmRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/request/VolunteerFcmRequest.java
@@ -1,0 +1,16 @@
+package com.pawwithu.connectdog.domain.fcm.dto.request;
+
+import com.pawwithu.connectdog.domain.fcm.entity.VolunteerFcm;
+import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
+import jakarta.validation.constraints.NotBlank;
+
+public record VolunteerFcmRequest(@NotBlank(message = "fcm 토큰은 필수 입력 값입니다.")
+                                  String fcmToken) {
+
+    public static VolunteerFcm volunteerToEntity(Volunteer volunteer, VolunteerFcmRequest request) {
+        return VolunteerFcm.builder()
+                .volunteer(volunteer)
+                .fcmToken(request.fcmToken)
+                .build();
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/entity/IntermediaryFcm.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/entity/IntermediaryFcm.java
@@ -1,0 +1,32 @@
+package com.pawwithu.connectdog.domain.fcm.entity;
+
+import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class IntermediaryFcm {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String fcmToken;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "intermediary_id", nullable = false)
+    private Intermediary intermediary;
+
+    @Builder
+    public IntermediaryFcm(String fcmToken, Intermediary intermediary) {
+        this.fcmToken = fcmToken;
+        this.intermediary = intermediary;
+    }
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/entity/VolunteerFcm.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/entity/VolunteerFcm.java
@@ -1,0 +1,32 @@
+package com.pawwithu.connectdog.domain.fcm.entity;
+
+import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class VolunteerFcm {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String fcmToken;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "volunteer_id", nullable = false)
+    private Volunteer volunteer;
+
+    @Builder
+    public VolunteerFcm(String fcmToken, Volunteer volunteer) {
+        this.fcmToken = fcmToken;
+        this.volunteer = volunteer;
+    }
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/repository/IntermediaryFcmRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/repository/IntermediaryFcmRepository.java
@@ -1,0 +1,7 @@
+package com.pawwithu.connectdog.domain.fcm.repository;
+
+import com.pawwithu.connectdog.domain.fcm.entity.IntermediaryFcm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IntermediaryFcmRepository extends JpaRepository<IntermediaryFcm, Long> {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/repository/VolunteerFcmRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/repository/VolunteerFcmRepository.java
@@ -1,0 +1,7 @@
+package com.pawwithu.connectdog.domain.fcm.repository;
+
+import com.pawwithu.connectdog.domain.fcm.entity.VolunteerFcm;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VolunteerFcmRepository extends JpaRepository<VolunteerFcm, Long> {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/service/FcmService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/service/FcmService.java
@@ -1,0 +1,124 @@
+package com.pawwithu.connectdog.domain.fcm.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.common.net.HttpHeaders;
+import com.pawwithu.connectdog.domain.fcm.dto.request.FcmMessage;
+import com.pawwithu.connectdog.domain.fcm.dto.request.IntermediaryFcmRequest;
+import com.pawwithu.connectdog.domain.fcm.dto.request.VolunteerFcmRequest;
+import com.pawwithu.connectdog.domain.fcm.entity.IntermediaryFcm;
+import com.pawwithu.connectdog.domain.fcm.entity.VolunteerFcm;
+import com.pawwithu.connectdog.domain.fcm.repository.IntermediaryFcmRepository;
+import com.pawwithu.connectdog.domain.fcm.repository.VolunteerFcmRepository;
+import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
+import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
+import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
+import com.pawwithu.connectdog.domain.volunteer.repository.VolunteerRepository;
+import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import static com.pawwithu.connectdog.error.ErrorCode.INTERMEDIARY_NOT_FOUND;
+import static com.pawwithu.connectdog.error.ErrorCode.VOLUNTEER_NOT_FOUND;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class FcmService {
+
+    @Value("${fcm.config.path}")
+    private String FIREBASE_CONFIG_PATH;
+
+    @Value("${fcm.api.url}")
+    private String FIREBASE_API_URL;
+
+    private final ObjectMapper objectMapper;
+    private final VolunteerRepository volunteerRepository;
+    private final VolunteerFcmRepository volunteerFcmRepository;
+    private final IntermediaryRepository intermediaryRepository;
+    private final IntermediaryFcmRepository intermediaryFcmRepository;
+
+    private String getAccessToken() throws IOException {
+
+        // firebase로 부터 access token을 가져온다.
+        GoogleCredentials googleCredentials = GoogleCredentials
+                .fromStream(new ClassPathResource(FIREBASE_CONFIG_PATH).getInputStream())
+                .createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
+
+        googleCredentials.refreshIfExpired();
+        return googleCredentials.getAccessToken().getTokenValue();
+
+    }
+
+    /**
+     * makeMessage : 알림 파라미터들을 FCM이 요구하는 body 형태로 가공한다.
+     * @param targetToken : firebase token
+     * @param title : 알림 제목
+     * @param body : 알림 내용
+     * @return
+     * */
+    public String makeMessage(String targetToken, String title, String body) throws JsonProcessingException {
+
+        FcmMessage fcmMessage = FcmMessage.builder()
+                .message(
+                        FcmMessage.Message.builder()
+                                .token(targetToken)
+                                .notification(
+                                        FcmMessage.Notification.builder()
+                                                .title(title)
+                                                .body(body)
+                                                .build())
+                                .build()
+                )
+                .validateOnly(false)
+                .build();
+
+        return objectMapper.writeValueAsString(fcmMessage);
+
+    }
+
+    /**
+     * 알림 푸쉬를 보내는 역할을 하는 메서드
+     * @param targetToken : 푸쉬 알림을 받을 클라이언트 앱의 식별 토큰
+     * */
+    public void sendMessageTo(String targetToken, String title, String body) throws IOException {
+
+        String message = makeMessage(targetToken, title, body);
+
+        OkHttpClient client = new OkHttpClient();
+        RequestBody requestBody = RequestBody.create(message, MediaType.get("application/json; charset=utf-8"));
+
+        Request request = new Request.Builder()
+                .url(FIREBASE_API_URL)
+                .post(requestBody)
+                .addHeader(HttpHeaders.AUTHORIZATION, "Bearer "+getAccessToken())
+                .addHeader(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8")
+                .build();
+
+        Response response = client.newCall(request).execute();
+        log.info(response.body().string());
+        return;
+    }
+
+    public void saveVolunteerFcm(String email, VolunteerFcmRequest request) {
+        Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
+        VolunteerFcm volunteerFcm = VolunteerFcmRequest.volunteerToEntity(volunteer, request);
+        volunteerFcmRepository.save(volunteerFcm);
+    }
+
+    public void saveIntermediaryFcm(String email, IntermediaryFcmRequest request) {
+        Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
+        IntermediaryFcm intermediaryFcm = IntermediaryFcmRequest.IntermediaryToEntity(intermediary, request);
+        intermediaryFcmRepository.save(intermediaryFcm);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/dto/request/PostSearchRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/dto/request/PostSearchRequest.java
@@ -8,7 +8,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import java.time.LocalDate;
 
 public record PostSearchRequest(@RequestParam(value = "postStatus", required = false) PostStatus postStatus,
-                                String departureLoc,
+                                @RequestParam(value = "departureLoc", required = false) String departureLoc,
+                                @RequestParam(value = "arrivalLoc", required = false)
                                 String arrivalLoc,
                                 @DateTimeFormat(pattern = "yyyy-MM-dd")
                                 LocalDate startDate,
@@ -16,7 +17,9 @@ public record PostSearchRequest(@RequestParam(value = "postStatus", required = f
                                 LocalDate endDate,
                                 @RequestParam(value = "dogSize", required = false) DogSize dogSize,
                                 Boolean isKennel,
+                                @RequestParam(value = "intermediaryName", required = false)
                                 String intermediaryName,
+                                @RequestParam(value = "orderCondition", required = false)
                                 String orderCondition) {
     
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/fcm/controller/FcmControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/fcm/controller/FcmControllerTest.java
@@ -1,0 +1,77 @@
+package com.pawwithu.connectdog.domain.fcm.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pawwithu.connectdog.domain.application.dto.request.VolunteerApplyRequest;
+import com.pawwithu.connectdog.domain.fcm.dto.request.IntermediaryFcmRequest;
+import com.pawwithu.connectdog.domain.fcm.dto.request.VolunteerFcmRequest;
+import com.pawwithu.connectdog.domain.fcm.service.FcmService;
+import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class FcmControllerTest {
+
+    @InjectMocks
+    private FcmController fcmController;
+    @Mock
+    private FcmService fcmService;
+    private ObjectMapper objectMapper = new ObjectMapper();
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(fcmController)
+                .setCustomArgumentResolvers(new TestUserArgumentResolver(), new PageableHandlerMethodArgumentResolver())
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .build();
+    }
+
+    @Test
+    void 이동봉사자_FCM_토큰_저장() throws Exception{
+        //given
+        VolunteerFcmRequest request = new VolunteerFcmRequest("fcmToken");
+
+        //when
+        ResultActions result = mockMvc.perform(
+                post("/volunteers/fcm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+        //then
+        result.andExpect(status().isNoContent());
+        verify(fcmService, times(1)).saveVolunteerFcm(anyString(), any());
+    }
+
+    @Test
+    void 이동봉사_중개_FCM_토큰_저장() throws Exception{
+        //given
+        IntermediaryFcmRequest request = new IntermediaryFcmRequest("fcmToken");
+
+        //when
+        ResultActions result = mockMvc.perform(
+                post("/intermediaries/fcm")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+        //then
+        result.andExpect(status().isNoContent());
+        verify(fcmService, times(1)).saveIntermediaryFcm(anyString(), any());
+    }
+}


### PR DESCRIPTION
## 💡 연관된 이슈
close #114 

## 📝 작업 내용
- Firebase 설정
- FcmService 구현
- Volunteer, Intermediary 별로 fcm 토큰 Entity 생성
- FCM 토큰 저장 API 구현
- FCM 토큰 저장 Controller 테스트 코드 추가

## 💬 리뷰 요구 사항
이동봉사자, 이동봉사 중개 모두 FCM 토큰과 다대일 관계라고 생각합니다!
(각각의 사용자가 여러 기기를 가질 수 있기 때문)
따라서 각각의 FCM 토큰 저장을 위한 Entity를 만들었는데 이 부분이 최선일지 고민입니다.

또한 현재 FCM 토큰을 받아오지 못 해, 푸시 알림 테스트는 따로 하지 못했습니다!
