### PR TITLE
[Feature] FCM Enum Message 생성 및 테스트 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ dependencies {
 	// firebase
 	implementation 'com.google.firebase:firebase-admin:6.8.1'
 	implementation group: 'com.squareup.okhttp3', name: 'okhttp', version: '4.2.2'
+	implementation 'com.squareup.okio:okio:2.7.0'
 }
 
 // Querydsl 설정부

--- a/src/main/java/com/pawwithu/connectdog/config/SecurityConfig.java
+++ b/src/main/java/com/pawwithu/connectdog/config/SecurityConfig.java
@@ -77,6 +77,7 @@ public class SecurityConfig {
                                 .requestMatchers(mvcMatcherBuilder.pattern("/swagger-resources/**")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/v3/api-docs/**")).permitAll()
                                 .requestMatchers(mvcMatcherBuilder.pattern("/volunteers/nickname/isDuplicated")).permitAll()
+                                .requestMatchers(mvcMatcherBuilder.pattern("/fcm-test")).permitAll()
                                 .anyRequest().authenticated())
                 .addFilterAfter(customVolunteerAuthFilter(), LogoutFilter.class)
                 .addFilterAfter(customIntermediaryAuthFilter(), LogoutFilter.class)

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/controller/FcmController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/controller/FcmController.java
@@ -1,5 +1,6 @@
 package com.pawwithu.connectdog.domain.fcm.controller;
 
+import com.pawwithu.connectdog.domain.fcm.dto.request.FcmTokenRequest;
 import com.pawwithu.connectdog.domain.fcm.dto.request.IntermediaryFcmRequest;
 import com.pawwithu.connectdog.domain.fcm.dto.request.VolunteerFcmRequest;
 import com.pawwithu.connectdog.domain.fcm.service.FcmService;
@@ -17,6 +18,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.pawwithu.connectdog.domain.fcm.dto.NotificationMessage.APPLICATION;
 
 @Tag(name = "Fcm", description = "Fcm API")
 @RestController
@@ -52,4 +55,17 @@ public class FcmController {
         fcmService.saveIntermediaryFcm(loginUser.getUsername(), request);
         return ResponseEntity.noContent().build();
     }
+
+    @Operation(summary = "FCM 토큰 테스트", description = "FCM 토큰을 테스트 합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "FCM 토큰 테스트 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "V1, fcm 토큰은 필수 입력 값입니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @PostMapping("/fcm-test")
+    public ResponseEntity<Void> testFcmToken(@Valid @RequestBody FcmTokenRequest request) {
+        fcmService.sendMessageTo(request.fcmToken(), APPLICATION.getTitleWithLoc("서울 강남구", "서울 도봉구"), APPLICATION.getBodyWithName("포윗유"));
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/FcmMessage.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/FcmMessage.java
@@ -1,4 +1,4 @@
-package com.pawwithu.connectdog.domain.fcm.dto.request;
+package com.pawwithu.connectdog.domain.fcm.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/NotificationMessage.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/NotificationMessage.java
@@ -1,0 +1,22 @@
+package com.pawwithu.connectdog.domain.fcm.dto;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationMessage {
+    APPLICATION("", "님이 이동봉사를 신청하셨어요. 지금 확인해 보세요!");
+
+    private final String title;
+    private final String body;
+
+    public String getTitleWithLoc(String departureLoc, String arrivalLoc) {
+        return departureLoc + "→" + arrivalLoc;
+    }
+
+    public String getBodyWithName(String name) {
+        return name + body;
+    }
+
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/request/FcmTokenRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/request/FcmTokenRequest.java
@@ -1,0 +1,7 @@
+package com.pawwithu.connectdog.domain.fcm.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record FcmTokenRequest(@NotBlank(message = "fcm 토큰은 필수 입력 값입니다.")
+                              String fcmToken) {
+}

--- a/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
+++ b/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
@@ -40,7 +40,9 @@ public enum ErrorCode {
     APPLICATION_NOT_FOUND("AP2", "해당 신청 내역을 찾을 수 없습니다."),
 
     REVIEW_NOT_FOUND("R1", "해당 후기를 찾을 수 없습니다."),
-    DOG_STATUS_NOT_FOUND("D1", "해당 근황을 찾을 수 없습니다.");
+    DOG_STATUS_NOT_FOUND("D1", "해당 근황을 찾을 수 없습니다."),
+
+    NOTIFICATION_SEND_ERROR("N1", "알림 전송을 실패했습니다.");
 
 
     private final String code;


### PR DESCRIPTION
## 💡 연관된 이슈
close #129 

## 📝 작업 내용
- Enum 타입 NotificationMessage 생성
- FCM 테스트 API 구현

## 💬 리뷰 요구 사항
상황별로 알림 메시지를 보여주기 위해 NotificationMessage를 Enum 타입으로 만들었습니다!
ErrorCode와 같은 형식이라고 생각하면 이해하기 쉬울 것 같습니다!

또한 테스트 코드를 실행하는 데 있어 의존성 문제가 발견되었습니다. (실행에는 문제 없음)
```
User
Errors occurred while building effective model from C:\Users\m\.gradle\caches\modules-2\files-2.1\com.squareup.okio\okio\2.2.2\bed31d1a3df050fdbc028510e3d92ac4bbc9e4bb\okio-2.2.2.pom:
	'dependencies.dependency[com.squareup.okio:okio:2.2.2]' for com.squareup.okio:okio:2.2.2 is referencing itself. in com.squareup.okio:okio:2.2.2
```
build.gradle에 해당 의존성 관련 설정은 없었지만, 에러가 발생할 가능성을 대비해 의존성 버전을 업데이트해 해결했습니다.

그리고 저희가 현재 이동봉사자와 이동봉사 중개 테이블이 나뉘어서 FCM token도 따로 각각 테이블을 만들어서 저장해뒀는데, 컬럼에 FCM token을 넣는 것과 현재 방식 중에 어떤 방식이 더 좋을지 고민입니다! 
컬럼에 저장하는 건 정규화에 맞지 않는 설계인 거 같다고 생각해 테이블을 분리했는데 고민입니다!