### PR TITLE
[Feature] 이동봉사자/중개 로그아웃 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/AuthController.java
@@ -1,6 +1,7 @@
 package com.pawwithu.connectdog.domain.auth.controller;
 
 import com.pawwithu.connectdog.domain.auth.dto.request.RefreshTokenRequest;
+import com.pawwithu.connectdog.domain.auth.service.AuthService;
 import com.pawwithu.connectdog.domain.oauth.dto.response.LoginResponse;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
 import com.pawwithu.connectdog.jwt.service.JwtService;
@@ -8,10 +9,15 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
     private final JwtService jwtService;
+    private final AuthService authService;
 
     @Operation(summary = "토큰 재발행", description = "AccessToken, RefreshToken 재발행 합니다.",
             responses = {@ApiResponse(responseCode = "200", description = "토큰 재발행 성공")
@@ -35,6 +42,32 @@ public class AuthController {
         String refreshToken = request.refreshToken();
         LoginResponse response = jwtService.reIssueToken(refreshToken);
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "이동봉사자 - 로그아웃", description = "이동봉사자가 로그아웃을 합니다.",
+            security = {@SecurityRequirement(name = "bearer-key") },
+            responses = {@ApiResponse(responseCode = "200", description = "이동봉사자 로그아웃 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "T1, 토큰이 존재하지 않습니다. \t\n M1, 해당 이동봉사자를 찾을 수 없습니다. \t\n M4, 해당 토큰에서 ROLE_NAME을 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @DeleteMapping("/volunteers/logout")
+    public ResponseEntity<Void> volunteersLogout(HttpServletRequest request, @AuthenticationPrincipal UserDetails loginUser) {
+        authService.volunteersLogout(request, loginUser.getUsername());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "로그아웃", description = "로그아웃을 합니다.",
+            security = {@SecurityRequirement(name = "bearer-key") },
+            responses = {@ApiResponse(responseCode = "200", description = "로그아웃 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "T1, 토큰이 존재하지 않습니다. \t\n M2, 해당 이동봉사 중개를 찾을 수 없습니다. \t\n M4, 해당 토큰에서 ROLE_NAME을 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @DeleteMapping("/intermediaries/logout")
+    public ResponseEntity<Void> intermediariesLogout(HttpServletRequest request, @AuthenticationPrincipal UserDetails loginUser) {
+        authService.intermediariesLogout(request, loginUser.getUsername());
+        return ResponseEntity.noContent().build();
     }
 
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
@@ -96,7 +96,7 @@ public class AuthService {
         String roleName = jwtService.extractRoleName(accessToken).orElseThrow(() -> new BadRequestException(NOT_FOUND_ROLE_NAME));
 
         redisUtil.delete(roleName, volunteer.getId());
-        volunteerFcmRepository.deleteById(volunteer.getId());
+        volunteerFcmRepository.deleteByVolunteerId(volunteer.getId());
         redisUtil.setBlackList(accessToken, "accessToken", jwtService.getAccessTokenExpirationPeriod());
     }
 
@@ -106,7 +106,7 @@ public class AuthService {
         String roleName = jwtService.extractRoleName(accessToken).orElseThrow(() -> new BadRequestException(NOT_FOUND_ROLE_NAME));
 
         redisUtil.delete(roleName, intermediary.getId());
-        intermediaryFcmRepository.deleteById(intermediary.getId());
+        intermediaryFcmRepository.deleteByIntermediaryId(intermediary.getId());
         redisUtil.setBlackList(accessToken, "accessToken", jwtService.getAccessTokenExpirationPeriod());
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/repository/IntermediaryFcmRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/repository/IntermediaryFcmRepository.java
@@ -4,4 +4,5 @@ import com.pawwithu.connectdog.domain.fcm.entity.IntermediaryFcm;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface IntermediaryFcmRepository extends JpaRepository<IntermediaryFcm, Long> {
+    void deleteByIntermediaryId(Long id);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/repository/VolunteerFcmRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/repository/VolunteerFcmRepository.java
@@ -4,4 +4,5 @@ import com.pawwithu.connectdog.domain.fcm.entity.VolunteerFcm;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface VolunteerFcmRepository extends JpaRepository<VolunteerFcm, Long> {
+    void deleteByVolunteerId(Long id);
 }

--- a/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
+++ b/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
     VOLUNTEER_NOT_FOUND("M1", "해당 이동봉사자를 찾을 수 없습니다."), // Member -> M (이동봉사자, 이동봉사 중개 통일)
     INTERMEDIARY_NOT_FOUND("M2", "해당 이동봉사 중개를 찾을 수 없습니다."),
     INVALID_ROLE_NAME("M3", "해당 ROLE_NAME을 가진 이동봉사자/중개를 찾을 수 없습니다."),
+    NOT_FOUND_ROLE_NAME("M4", "해당 토큰에서 ROLE_NAME을 찾을 수 없습니다."),
 
     TOKEN_NOT_EXIST("T1", "토큰이 존재하지 않습니다."),
     TOKEN_IS_EXPIRED("T2", "만료된 토큰입니다."),


### PR DESCRIPTION
## 💡 연관된 이슈
close #131 

## 📝 작업 내용
- 이동봉사자/중개 로그아웃 API 구현

## 💬 리뷰 요구 사항
로그아웃 기능 구현은 처음이라 맞게 했는지 한 번 봐주시면 좋을 것 같아요~! 
제가 생각하고 구현한 로그아웃 플로우는 다음과 같습니다.

1. accessToken을 추출한다. 
3. volunteer/intermediary 객체를 찾는다.
4. redis에 저장했던 roleName을 accessToken에서 찾아온다.
5. redis에 해당 roleName + id에 해당하는 key를 찾아 지운다.
6. redis에 해당 accessToken을 blackList로 등록한다.
