### PR TITLE
[Feature] 이동봉사자 봉사 관리 - 목록 조회 API 추가 수정

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationVolunteerCompletedResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationVolunteerCompletedResponse.java
@@ -1,17 +1,23 @@
 package com.pawwithu.connectdog.domain.application.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
 
 import java.time.LocalDate;
 
-public record ApplicationVolunteerCompletedResponse(Long postId, String mainImage,
-                                                    String departureLoc, String arrivalLoc,
+public record ApplicationVolunteerCompletedResponse(Long postId, String mainImage, String dogName, String departureLoc, String arrivalLoc,
                                                     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                                     LocalDate startDate,
                                                     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                                     LocalDate endDate,
                                                     String pickUpTime,
-                                                    String intermediaryName, Boolean isKennel,
+                                                    String dogSize,
+                                                    Boolean isKennel,
                                                     Long reviewId) {
-
+    public ApplicationVolunteerCompletedResponse(Long postId, String mainImage, String dogName, String departureLoc, String arrivalLoc,
+                                               LocalDate startDate, LocalDate endDate, String pickUpTime,
+                                               DogSize dogSize, Boolean isKennel, Long reviewId) {
+        this(postId, mainImage, dogName, departureLoc, arrivalLoc, startDate, endDate, pickUpTime,
+                dogSize.getKey(), isKennel, reviewId);
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationVolunteerProgressingResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationVolunteerProgressingResponse.java
@@ -1,15 +1,24 @@
 package com.pawwithu.connectdog.domain.application.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
 
 import java.time.LocalDate;
 
-public record ApplicationVolunteerProgressingResponse(Long postId, String mainImage, String departureLoc, String arrivalLoc,
+public record ApplicationVolunteerProgressingResponse(Long postId, String mainImage, String dogName, String departureLoc, String arrivalLoc,
                                                       @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
-                                             LocalDate startDate,
+                                                      LocalDate startDate,
                                                       @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
-                                             LocalDate endDate,
+                                                      LocalDate endDate,
                                                       String pickUpTime,
-                                                      String intermediaryName,
-                                                      Boolean isKennel) {
+                                                      String dogSize,
+                                                      Boolean isKennel,
+                                                      Long applicationId) {
+
+    public ApplicationVolunteerProgressingResponse(Long postId, String mainImage, String dogName, String departureLoc, String arrivalLoc,
+                                               LocalDate startDate, LocalDate endDate, String pickUpTime,
+                                               DogSize dogSize, Boolean isKennel, Long applicationId) {
+        this(postId, mainImage, dogName, departureLoc, arrivalLoc, startDate, endDate, pickUpTime,
+                dogSize.getKey(), isKennel, applicationId);
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationVolunteerWaitingResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationVolunteerWaitingResponse.java
@@ -1,16 +1,24 @@
 package com.pawwithu.connectdog.domain.application.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
 
 import java.time.LocalDate;
 
-public record ApplicationVolunteerWaitingResponse(Long postId, String mainImage, String departureLoc, String arrivalLoc,
+public record ApplicationVolunteerWaitingResponse(Long postId, String mainImage, String dogName, String departureLoc, String arrivalLoc,
                                                   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                          LocalDate startDate,
                                                   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                          LocalDate endDate,
                                                   String pickUpTime,
-                                                  String intermediaryName,
+                                                  String dogSize,
                                                   Boolean isKennel,
                                                   Long applicationId) {
+
+    public ApplicationVolunteerWaitingResponse(Long postId, String mainImage, String dogName, String departureLoc, String arrivalLoc,
+                                               LocalDate startDate, LocalDate endDate, String pickUpTime,
+                                               DogSize dogSize, Boolean isKennel, Long applicationId) {
+        this(postId, mainImage, dogName, departureLoc, arrivalLoc, startDate, endDate, pickUpTime,
+                dogSize.getKey(), isKennel, applicationId);
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -34,13 +34,13 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
     public List<ApplicationVolunteerWaitingResponse> getVolunteerWaitingApplications(Long volunteerId, Pageable pageable) {
         return queryFactory
                 .select(Projections.constructor(ApplicationVolunteerWaitingResponse.class,
-                        post.id, postImage.image, post.departureLoc, post.arrivalLoc,
+                        post.id, postImage.image, dog.name, post.departureLoc, post.arrivalLoc,
                         post.startDate, post.endDate, post.pickUpTime,
-                        intermediary.name, post.isKennel, application.id))
+                        dog.size, post.isKennel, application.id))
                 .from(application)
                 .join(application.post, post)
-                .join(application.post.intermediary, intermediary)
                 .join(application.post.mainImage, postImage)
+                .join(application.post.dog, dog)
                 .where(application.status.eq(ApplicationStatus.WAITING)
                         .and(application.volunteer.id.eq(volunteerId)))
                 .orderBy(application.createdDate.desc())    // 신청 최신순

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -53,13 +53,13 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
     public List<ApplicationVolunteerProgressingResponse> getVolunteerProgressingApplications(Long volunteerId, Pageable pageable) {
         return queryFactory
                 .select(Projections.constructor(ApplicationVolunteerProgressingResponse.class,
-                        post.id, postImage.image, post.departureLoc, post.arrivalLoc,
+                        post.id, postImage.image, dog.name, post.departureLoc, post.arrivalLoc,
                         post.startDate, post.endDate, post.pickUpTime,
-                        intermediary.name, post.isKennel))
+                        dog.size, post.isKennel, application.id))
                 .from(application)
                 .join(application.post, post)
-                .join(application.post.intermediary, intermediary)
                 .join(application.post.mainImage, postImage)
+                .join(application.post.dog, dog)
                 .where(application.status.eq(ApplicationStatus.PROGRESSING)
                         .and(application.volunteer.id.eq(volunteerId)))
                 .orderBy(application.modifiedDate.desc())   // 신청 확정 최신순

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -133,13 +133,13 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
     public List<ApplicationVolunteerCompletedResponse> getVolunteerCompletedApplications(Long volunteerId, Pageable pageable) {
         return queryFactory
                 .select(Projections.constructor(ApplicationVolunteerCompletedResponse.class,
-                        post.id, postImage.image, post.departureLoc, post.arrivalLoc,
+                        post.id, postImage.image, dog.name, post.departureLoc, post.arrivalLoc,
                         post.startDate, post.endDate, post.pickUpTime,
-                        intermediary.name, post.isKennel, review.id))
+                        dog.size, post.isKennel, review.id))
                 .from(application)
                 .join(application.post, post)
-                .join(application.post.intermediary, intermediary)
                 .join(application.post.mainImage, postImage)
+                .join(application.post.dog, dog)
                 .leftJoin(review).on(post.id.eq(review.post.id))
                 .where(application.status.eq(ApplicationStatus.COMPLETED)
                         .and(application.volunteer.id.eq(volunteerId)))

--- a/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pawwithu.connectdog.domain.application.dto.request.VolunteerApplyRequest;
 import com.pawwithu.connectdog.domain.application.dto.response.*;
 import com.pawwithu.connectdog.domain.application.service.ApplicationService;
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
 import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -76,10 +77,10 @@ class ApplicationControllerTest {
         List<ApplicationVolunteerWaitingResponse> response = new ArrayList<>();
         LocalDate startDate = LocalDate.of(2023, 10, 2);
         LocalDate endDate = LocalDate.of(2023, 11, 7);
-        response.add(new ApplicationVolunteerWaitingResponse(1L, "image1", "서울시 성북구", "서울시 중랑구",
-                startDate, endDate, "13:00","이동봉사 중개", true, 1L));
-        response.add(new ApplicationVolunteerWaitingResponse(2L, "image2", "서울시 성북구", "서울시 중랑구",
-                startDate, endDate, "13:00","이동봉사 중개", false, 2L));
+        response.add(new ApplicationVolunteerWaitingResponse(1L, "image1", "잔디", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true, 1L));
+        response.add(new ApplicationVolunteerWaitingResponse(2L, "image1", "잔디", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true, 1L));
 
         //when
         given(applicationService.getVolunteerWaitingApplications(anyString(), any())).willReturn(response);
@@ -98,10 +99,10 @@ class ApplicationControllerTest {
         List<ApplicationVolunteerProgressingResponse> response = new ArrayList<>();
         LocalDate startDate = LocalDate.of(2023, 10, 2);
         LocalDate endDate = LocalDate.of(2023, 11, 7);
-        response.add(new ApplicationVolunteerProgressingResponse(1L, "image1", "서울시 성북구", "서울시 중랑구",
-                startDate, endDate, "13:00", "이동봉사 중개", true));
-        response.add(new ApplicationVolunteerProgressingResponse(2L, "image2", "서울시 성북구", "서울시 중랑구",
-                startDate, endDate, "13:00", "이동봉사 중개", false));
+        response.add(new ApplicationVolunteerProgressingResponse(1L, "image1", "잔디", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true, 1L));
+        response.add(new ApplicationVolunteerProgressingResponse(2L, "image1", "잔디", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true, 1L));
 
         //when
         given(applicationService.getVolunteerProgressingApplications(anyString(), any())).willReturn(response);
@@ -237,10 +238,10 @@ class ApplicationControllerTest {
         List<ApplicationVolunteerCompletedResponse> response = new ArrayList<>();
         LocalDate startDate = LocalDate.of(2023, 10, 2);
         LocalDate endDate = LocalDate.of(2023, 11, 7);
-        response.add(new ApplicationVolunteerCompletedResponse(1L, "image1", "서울시 성북구", "서울시 중랑구",
-                startDate, endDate, "13:00", "이동봉사 중개", true, 1L));
-        response.add(new ApplicationVolunteerCompletedResponse(2L, "image2", "서울시 성북구", "서울시 중랑구",
-                startDate, endDate, "13:00","이동봉사 중개", false, null));
+        response.add(new ApplicationVolunteerCompletedResponse(1L, "image1", "잔디", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true, 1L));
+        response.add(new ApplicationVolunteerCompletedResponse(2L, "image1", "잔디", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true, 1L));
 
         //when
         given(applicationService.getVolunteerCompletedApplications(anyString(), any())).willReturn(response);


### PR DESCRIPTION
## 💡 연관된 이슈
close #161 

## 📝 작업 내용
이동봉사자 봉사 관리 - 목록 조회 시 강아지 이름, 강아지 크기 정보 추가 및 중개자 이름 정보 삭제
- 이동봉사자 승인 대기중 목록 조회 API 반환값 수정
- 이동봉사자 진행중 목록 조회 API 반환값 수정
- 이동봉사자 봉사 완료 목록 조회 API 반환값 수정
- 이동봉사자 봉사 관리 - 목록 조회 테스트 코드 수정

## 💬 리뷰 요구 사항