### PR TITLE
[Feature] 이동봉사 모집자 봉사 관리 - 목록 조회 API 수정

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationIntermediaryCompletedResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationIntermediaryCompletedResponse.java
@@ -1,15 +1,24 @@
 package com.pawwithu.connectdog.domain.application.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
 
 import java.time.LocalDate;
 
 public record ApplicationIntermediaryCompletedResponse(Long postId, String mainImage, String dogName,
+                                                       String departureLoc, String arrivalLoc,
                                                        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                                        LocalDate startDate,
                                                        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                                        LocalDate endDate,
-                                                       String departureLoc, String arrivalLoc,
-                                                       String volunteerName, Long applicationId,
-                                                       Long reviewId, Long dogStatusId) {
+                                                       String pickUpTime,
+                                                       String dogSize,
+                                                       Boolean isKennel,
+                                                       Long reviewId) {
+    public ApplicationIntermediaryCompletedResponse(Long postId, String mainImage, String dogName,
+                                                      String departureLoc, String arrivalLoc, LocalDate startDate, LocalDate endDate,
+                                                      String pickUpTime, DogSize dogSize, Boolean isKennel, Long reviewId) {
+        this(postId, mainImage, dogName, departureLoc, arrivalLoc, startDate, endDate, pickUpTime,
+                dogSize.getKey(), isKennel, reviewId);
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationIntermediaryProgressingResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationIntermediaryProgressingResponse.java
@@ -1,15 +1,26 @@
 package com.pawwithu.connectdog.domain.application.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 public record ApplicationIntermediaryProgressingResponse(Long postId, String mainImage, String dogName,
+                                                         String departureLoc, String arrivalLoc,
                                                          @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                                          LocalDate startDate,
                                                          @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                                          LocalDate endDate,
-                                                         String departureLoc, String arrivalLoc,
-                                                         String volunteerName,
+                                                         String pickUpTime,
+                                                         String dogSize,
+                                                         Boolean isKennel,
                                                          Long applicationId) {
+
+    public ApplicationIntermediaryProgressingResponse(Long postId, String mainImage, String dogName,
+                                                  String departureLoc, String arrivalLoc, LocalDate startDate, LocalDate endDate,
+                                                  String pickUpTime, DogSize dogSize, Boolean isKennel, Long applicationId) {
+        this(postId, mainImage, dogName, departureLoc, arrivalLoc, startDate, endDate, pickUpTime,
+                dogSize.getKey(), isKennel, applicationId);
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationIntermediaryWaitingResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/dto/response/ApplicationIntermediaryWaitingResponse.java
@@ -2,6 +2,7 @@ package com.pawwithu.connectdog.domain.application.dto.response;
 
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -9,11 +10,20 @@ import java.time.LocalDateTime;
 public record ApplicationIntermediaryWaitingResponse(@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm", timezone = "Asia/Seoul")
                                                      LocalDateTime applicationTime,
                                                      Long postId, String mainImage, String dogName,
+                                                     String departureLoc, String arrivalLoc,
                                                      @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                                      LocalDate startDate,
                                                      @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                                      LocalDate endDate,
-                                                     String departureLoc, String arrivalLoc,
-                                                     String volunteerName,
+                                                     String pickUpTime,
+                                                     String dogSize,
+                                                     Boolean isKennel,
                                                      Long applicationId) {
+
+    public ApplicationIntermediaryWaitingResponse(LocalDateTime applicationTime, Long postId, String mainImage, String dogName,
+                                                  String departureLoc, String arrivalLoc, LocalDate startDate, LocalDate endDate,
+                                                  String pickUpTime, DogSize dogSize, Boolean isKennel, Long applicationId) {
+        this(applicationTime, postId, mainImage, dogName, departureLoc, arrivalLoc, startDate, endDate, pickUpTime,
+                dogSize.getKey(), isKennel, applicationId);
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -95,13 +95,13 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
     public List<ApplicationIntermediaryWaitingResponse> getIntermediaryWaitingApplications(Long intermediaryId, Pageable pageable) {
         return queryFactory
                 .select(Projections.constructor(ApplicationIntermediaryWaitingResponse.class,
-                        application.createdDate, post.id, postImage.image, dog.name, post.startDate, post.endDate,
-                        post.departureLoc, post.arrivalLoc, volunteer.name, application.id))
+                        application.createdDate, post.id, postImage.image, dog.name,
+                        post.departureLoc, post.arrivalLoc, post.startDate, post.endDate, post.pickUpTime,
+                        dog.size, post.isKennel, application.id))
                 .from(application)
                 .join(application.post, post)
                 .join(application.post.mainImage, postImage)
                 .join(application.post.dog, dog)
-                .join(application.volunteer, volunteer)
                 .where(application.status.eq(ApplicationStatus.WAITING)
                         .and(application.intermediary.id.eq(intermediaryId)))
                 .orderBy(application.createdDate.desc())    // 신청 최신순

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -153,13 +153,13 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
     public List<ApplicationIntermediaryCompletedResponse> getIntermediaryCompletedApplications(Long intermediaryId, Pageable pageable) {
         return queryFactory
                 .select(Projections.constructor(ApplicationIntermediaryCompletedResponse.class,
-                        post.id, postImage.image, dog.name, post.startDate, post.endDate, post.departureLoc, post.arrivalLoc,
-                        volunteer.name, application.id, review.id, dogStatus.id))
+                        post.id, postImage.image, dog.name, post.departureLoc, post.arrivalLoc,
+                        post.startDate, post.endDate, post.pickUpTime,
+                        dog.size, post.isKennel, review.id))
                 .from(application)
                 .join(application.post, post)
                 .join(application.post.mainImage, postImage)
                 .join(application.post.dog, dog)
-                .join(application.volunteer, volunteer)
                 .leftJoin(review).on(post.id.eq(review.post.id))
                 .leftJoin(dogStatus).on(post.id.eq(dogStatus.post.id))
                 .where(application.status.eq(ApplicationStatus.COMPLETED)

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -114,13 +114,13 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
     public List<ApplicationIntermediaryProgressingResponse> getIntermediaryProgressingApplications(Long intermediaryId, Pageable pageable) {
         return queryFactory
                 .select(Projections.constructor(ApplicationIntermediaryProgressingResponse.class,
-                        post.id, postImage.image, dog.name, post.startDate, post.endDate,
-                        post.departureLoc, post.arrivalLoc, volunteer.name, application.id))
+                        post.id, postImage.image, dog.name, post.departureLoc, post.arrivalLoc,
+                        post.startDate, post.endDate, post.pickUpTime,
+                        dog.size, post.isKennel, application.id))
                 .from(application)
                 .join(application.post, post)
                 .join(application.post.mainImage, postImage)
                 .join(application.post.dog, dog)
-                .join(application.volunteer, volunteer)
                 .where(application.status.eq(ApplicationStatus.PROGRESSING)
                         .and(application.intermediary.id.eq(intermediaryId)))
                 .orderBy(application.modifiedDate.desc())   // 신청 확정 최신순

--- a/src/main/java/com/pawwithu/connectdog/domain/dog/entity/DogSize.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/dog/entity/DogSize.java
@@ -13,7 +13,7 @@ import static com.pawwithu.connectdog.error.ErrorCode.INVALID_DOG_SIZE;
 @RequiredArgsConstructor
 public enum DogSize {
 
-    SMALL("소형견"), MEDIUM("중형견"), LARGE("대형견");
+    SMALL("소형"), MEDIUM("중형"), LARGE("대형");
 
     @JsonCreator
     public static DogSize create(String requestValue) {

--- a/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
@@ -90,8 +90,8 @@ public class PostController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "봉사 관리 - 모집중, 모집 마감", description = "이동봉사 모집중, 모집 마감 목록을 조회합니다.",
-            responses = {@ApiResponse(responseCode = "200", description = "이동봉사 모집중, 모집 마감 목록 조회 성공")
+    @Operation(summary = "봉사 관리 - 공고 삭제", description = "이동봉사 공고를 삭제합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "이동봉사 공고 삭제 성공")
                     , @ApiResponse(responseCode = "400"
                     , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다. \t\n P2, 해당 공고를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))

--- a/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostRecruitingGetResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/dto/response/PostRecruitingGetResponse.java
@@ -1,21 +1,26 @@
 package com.pawwithu.connectdog.domain.post.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.pawwithu.connectdog.domain.dog.entity.DogSize;
 import com.pawwithu.connectdog.domain.post.entity.PostStatus;
 
 import java.time.LocalDate;
 
 public record PostRecruitingGetResponse(Long postId, String postStatus, String mainImage, String dogName,
+                                        String departureLoc, String arrivalLoc,
                                         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                         LocalDate startDate,
                                         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                         LocalDate endDate,
-                                        String departureLoc, String arrivalLoc,
-                                        String volunteerName) {
+                                        String pickUpTime,
+                                        String dogSize,
+                                        Boolean isKennel) {
 
     // 공고 이동봉사자 이름을 제외한 생성자
     public PostRecruitingGetResponse(Long postId, PostStatus postStatus, String mainImage, String dogName,
-                                     LocalDate startDate, LocalDate endDate, String departureLoc, String arrivalLoc) {
-        this(postId, postStatus.getKey(), mainImage, dogName, startDate, endDate, departureLoc, arrivalLoc, null);
+                                     String departureLoc, String arrivalLoc, LocalDate startDate, LocalDate endDate,
+                                     String pickUpTime, DogSize dogSize, Boolean isKennel) {
+        this(postId, postStatus.getKey(), mainImage, dogName, departureLoc, arrivalLoc,
+                startDate, endDate, pickUpTime, dogSize.getKey(), isKennel);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/entity/PostStatus.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/entity/PostStatus.java
@@ -13,7 +13,7 @@ import static com.pawwithu.connectdog.error.ErrorCode.INVALID_POST_STATUS;
 @RequiredArgsConstructor
 public enum PostStatus {
 
-    RECRUITING("모집중"), WAITING("승인 대기중"), PROGRESSING("진행중"), COMPLETED("봉사 완료"), EXPIRED("마감");
+    RECRUITING("모집중"), WAITING("승인 대기중"), PROGRESSING("진행중"), COMPLETED("봉사 완료"), EXPIRED("모집 마감");
 
     @JsonCreator
     public static PostStatus create(String requestValue) {

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
@@ -101,8 +101,8 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
     public List<PostRecruitingGetResponse> getRecruitingPosts(Long intermediaryId, Pageable pageable) {
         return queryFactory
                 .select(Projections.constructor(PostRecruitingGetResponse.class,
-                        post.id, post.status, postImage.image, dog.name, post.startDate, post.endDate,
-                        post.departureLoc, post.arrivalLoc))
+                        post.id, post.status, postImage.image, dog.name, post.departureLoc, post.arrivalLoc,
+                        post.startDate, post.endDate, post.pickUpTime, dog.size, post.isKennel))
                 .from(post)
                 .join(post.mainImage, postImage)
                 .join(post.dog, dog)

--- a/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/application/controller/ApplicationControllerTest.java
@@ -191,10 +191,10 @@ class ApplicationControllerTest {
         LocalDateTime applicationTime = LocalDateTime.of(2023, 11, 25, 12, 30);
         LocalDate startDate = LocalDate.of(2023, 10, 2);
         LocalDate endDate = LocalDate.of(2023, 11, 7);
-        response.add(new ApplicationIntermediaryWaitingResponse(applicationTime, 1L, "image1", "포포1", startDate, endDate,
-                "서울시 성북구", "서울시 중랑구", "하노정", 1L));
-        response.add(new ApplicationIntermediaryWaitingResponse(applicationTime, 2L, "image2", "포포2", startDate, endDate,
-                "서울시 성북구", "서울시 중랑구", "민경혁", 2L));
+        response.add(new ApplicationIntermediaryWaitingResponse(applicationTime, 1L, "image1", "포포1", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true, 1L));
+        response.add(new ApplicationIntermediaryWaitingResponse(applicationTime, 2L, "image1", "포포1", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true, 2L));
 
 
         //when
@@ -215,10 +215,11 @@ class ApplicationControllerTest {
         List<ApplicationIntermediaryProgressingResponse> response = new ArrayList<>();
         LocalDate startDate = LocalDate.of(2023, 10, 2);
         LocalDate endDate = LocalDate.of(2023, 11, 7);
-        response.add(new ApplicationIntermediaryProgressingResponse(1L, "image1", "포포1", startDate, endDate,
-                "서울시 성북구", "서울시 중랑구", "하노정", 1L));
-        response.add(new ApplicationIntermediaryProgressingResponse(2L, "image2", "포포2", startDate, endDate,
-                "서울시 성북구", "서울시 중랑구", "민경혁", 2L));
+        response.add(new ApplicationIntermediaryProgressingResponse(1L, "image1", "포포1", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true, 1L));
+        response.add(new ApplicationIntermediaryProgressingResponse(2L, "image1", "포포1", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true, 2L));
+
 
 
         //when
@@ -241,7 +242,7 @@ class ApplicationControllerTest {
         response.add(new ApplicationVolunteerCompletedResponse(1L, "image1", "잔디", "서울시 성북구", "서울시 중랑구",
                 startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true, 1L));
         response.add(new ApplicationVolunteerCompletedResponse(2L, "image1", "잔디", "서울시 성북구", "서울시 중랑구",
-                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true, 1L));
+                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true, 2L));
 
         //when
         given(applicationService.getVolunteerCompletedApplications(anyString(), any())).willReturn(response);
@@ -260,12 +261,10 @@ class ApplicationControllerTest {
         List<ApplicationIntermediaryCompletedResponse> response = new ArrayList<>();
         LocalDate startDate = LocalDate.of(2023, 10, 2);
         LocalDate endDate = LocalDate.of(2023, 11, 7);
-        response.add(new ApplicationIntermediaryCompletedResponse(1L, "image1", "포포",
-                startDate, endDate, "이동봉사 중개", "서울시 성북구", "서울시 중랑구",
-                1L, 1L, null));
-        response.add(new ApplicationIntermediaryCompletedResponse(2L, "image1", "포포",
-                startDate, endDate, "이동봉사 중개", "서울시 성북구", "서울시 중랑구",
-                1L, 1L, null));
+        response.add(new ApplicationIntermediaryCompletedResponse(1L, "image1", "잔디", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true, 1L));
+        response.add(new ApplicationIntermediaryCompletedResponse(2L, "image1", "잔디", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true, 2L));
 
         //when
         given(applicationService.getIntermediaryCompletedApplications(anyString(), any())).willReturn(response);

--- a/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/post/controller/PostControllerTest.java
@@ -174,10 +174,10 @@ class PostControllerTest {
         List<PostRecruitingGetResponse> response = new ArrayList<>();
         LocalDate startDate = LocalDate.of(2023, 10, 2);
         LocalDate endDate = LocalDate.of(2023, 11, 7);
-        response.add(new PostRecruitingGetResponse(1L, PostStatus.RECRUITING, "image1", "포포1", startDate, endDate,
-                "서울시 성북구", "서울시 중랑구"));
-        response.add(new PostRecruitingGetResponse(2L, PostStatus.EXPIRED, "image2", "포포2", startDate, endDate,
-                "서울시 성북구", "서울시 중랑구"));
+        response.add(new PostRecruitingGetResponse(1L, PostStatus.RECRUITING.getKey(), "image1", "잔디", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true));
+        response.add(new PostRecruitingGetResponse(2L, PostStatus.RECRUITING.getKey(), "image1", "잔디", "서울시 성북구", "서울시 중랑구",
+                startDate, endDate, "13:00", DogSize.MEDIUM.getKey(), true));
 
 
         //when


### PR DESCRIPTION
## 💡 연관된 이슈
close #163 

## 📝 작업 내용
- 이동봉사 모집자 봉사 관리 - 모집중, 승인 대기중, 진행중, 봉사 완료 목록 조회 API 반환값 수정
- DogSize enum 값 "소형견" -> "소형" 형식으로 수정
- PostStatus enum 값 "마감" -> "모집 마감" 수정
- 이동봉사 모집자 봉사 관리 목록 조회 테스트 코드 수정

## 💬 리뷰 요구 사항
모집중이 날짜가 지난 후 모집 마감이 되어야 하는 것을 배치 작업으로 진행해야 할 것 같습니다!
자신의 신청이 반려됐을 때 목록에 보여주는 걸 어떻게 구현할까 고민 중인데, 현재 작업한 동시성 문제 해결을 다른 방법으로 진행하고 신청의 상태 enum 값에 "반려" 값을 추가할지 고민 중입니다.