### PR TITLE
[Feature] 이동봉사자, 모집자 자체 회원가입 API 수정

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
@@ -35,7 +35,7 @@ public class SignUpController {
             responses = {@ApiResponse(responseCode = "204", description = "이동봉사자 자체 회원가입 성공")
                     , @ApiResponse(responseCode = "400"
                     , description = "V1, 이메일 형식에 맞지 않습니다. \t\n V1, 이메일은 필수 입력 값입니다. \t\n V1, 영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상을 입력해 주세요. \t\n " +
-                    "V1, 닉네임은 한글, 숫자만 사용 가능합니다. \t\n V1, 닉네임은 필수 입력 값입니다. \t\n V1, 닉네임은 2~10자로 입력해 주세요. \t\n A1, 이미 등록된 이메일입니다. \t\n A2, 이미 사용 중인 닉네임입니다."
+                    "V1, 닉네임은 한글, 숫자만 사용 가능합니다. \t\n V1, 닉네임은 필수 입력 값입니다. \t\n V1, 닉네임은 2~10자로 입력해 주세요. \t\n A1, 이미 등록된 이메일입니다. \t\n A2, 이미 사용 중인 닉네임입니다. \t\n A8, 이미 등록된 전화번호입니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PostMapping("/volunteers/sign-up")

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
@@ -34,7 +34,8 @@ public class SignUpController {
     @Operation(summary = "이동봉사자 자체 회원가입", description = "이동봉사자 자체 회원가입을 합니다.",
             responses = {@ApiResponse(responseCode = "204", description = "이동봉사자 자체 회원가입 성공")
                     , @ApiResponse(responseCode = "400"
-                    , description = "V1, 이메일 형식에 맞지 않습니다. \t\n V1, 이메일은 필수 입력 값입니다. \t\n V1, 영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상을 입력해 주세요. \t\n " +
+                    , description = "V1, 이름은 필수 입력 값입니다. \t\n V1, 이메일 형식에 맞지 않습니다. \t\n V1, 휴대전화 번호는 필수 입력 값입니다. \t\n V1, 유효하지 않은 휴대전화 번호입니다. \t\n " +
+                    "V1, 이메일은 필수 입력 값입니다. \t\n V1, 영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상을 입력해 주세요. \t\n " +
                     "V1, 닉네임은 한글, 숫자만 사용 가능합니다. \t\n V1, 닉네임은 필수 입력 값입니다. \t\n V1, 닉네임은 2~10자로 입력해 주세요. \t\n A1, 이미 등록된 이메일입니다. \t\n A2, 이미 사용 중인 닉네임입니다. \t\n A8, 이미 등록된 전화번호입니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
@@ -47,8 +48,9 @@ public class SignUpController {
     @Operation(summary = "이동봉사 중개 자체 회원가입", description = "이동봉사 중개 자체 회원가입을 합니다.",
             responses = {@ApiResponse(responseCode = "204", description = "이동봉사 중개 자체 회원가입 성공")
                     , @ApiResponse(responseCode = "400"
-                    , description = "V1, 이메일 형식에 맞지 않습니다. \t\n V1, 이메일은 필수 입력 값입니다. \t\n " +
-                    "V1, 영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상을 입력해 주세요. \t\n V1, 이름/단체명은 필수 입력 값입니다. \t\n V1, url 형식을 입력해 주세요. \t\n " +
+                    , description = "V1, 이름은 필수 입력 값입니다 \t\n V1, 휴대전화 번호는 필수 입력 값입니다. \t\n V1, 유효하지 않은 휴대전화 번호입니다. \t\n " +
+                    "V1, 이메일 형식에 맞지 않습니다. \t\n V1, 이메일은 필수 입력 값입니다. \t\n " +
+                    "V1, 영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상을 입력해 주세요. \t\n V1, 모집자명은 필수 입력 값입니다. \t\n V1, url 형식을 입력해 주세요. \t\n " +
                     "V1, 한줄 소개는 50자 이하로 입력해 주세요. \t\n A1, 이미 등록된 이메일입니다. \t\n F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/IntermediarySignUpRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/IntermediarySignUpRequest.java
@@ -7,21 +7,32 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
-public record IntermediarySignUpRequest(@Email(message="이메일 형식에 맞지 않습니다.")
-                                        @NotBlank(message = "이메일은 필수 입력 값입니다.") String email,
+public record IntermediarySignUpRequest(Boolean isOptionAgr,
+                                        @NotBlank(message = "이름은 필수 입력 값입니다.")
+                                        String realName,
+                                        @NotBlank(message = "휴대전화 번호는 필수 입력 값입니다.")
+                                        @Pattern(regexp = "^010[0-9]{8}$", message = "유효하지 않은 휴대전화 번호입니다.")
+                                        String phone,
+                                        @Email(message="이메일 형식에 맞지 않습니다.")
+                                        @NotBlank(message = "이메일은 필수 입력 값입니다.")
+                                        String email,
                                         @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d).{10,}$|^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=?]).{8,}$",
-                                                message = "영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상을 입력해 주세요.") String password,
-                                        @NotBlank(message = "이름/단체명은 필수 입력 값입니다.")
+                                                message = "영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상을 입력해 주세요.")
+                                        String password,
+                                        @NotBlank(message = "모집자명은 필수 입력 값입니다.")
                                         String name,
-                                        @Pattern(regexp = "^(http|https)://[a-zA-Z0-9-.]+\\.[a-zA-Z]{2,}(/\\S*)?$",
-                                                message = "url 형식을 입력해 주세요.") String url,
                                         @Size(max=50, message = "한줄 소개는 50자 이하로 입력해 주세요.")
                                         String intro,
-                                        String contact,
-                                        Boolean isOptionAgr) {
+                                        @Pattern(regexp = "^(http|https)://[a-zA-Z0-9-.]+\\.[a-zA-Z]{2,}(/\\S*)?$",
+                                                message = "url 형식을 입력해 주세요.")
+                                        String url,
+                                        String contact) {
 
     public static Intermediary toEntity(IntermediarySignUpRequest request, String authImage, String profileImage) {
         return Intermediary.builder()
+                .isOptionAgr(request.isOptionAgr)
+                .realName(request.realName)
+                .phone(request.phone)
                 .email(request.email)
                 .password(request.password)
                 .name(request.name)
@@ -30,7 +41,6 @@ public record IntermediarySignUpRequest(@Email(message="이메일 형식에 맞�
                 .profileImage(profileImage)
                 .intro(request.intro)
                 .contact(request.contact)
-                .isOptionAgr(request.isOptionAgr)
                 .role(IntermediaryRole.INTERMEDIARY)
                 .notification(true)
                 .build();

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/VolunteerSignUpRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/dto/request/VolunteerSignUpRequest.java
@@ -7,26 +7,35 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
-public record VolunteerSignUpRequest(@Email(message="이메일 형식에 맞지 않습니다.")
-                                     @NotBlank(message = "이메일은 필수 입력 값입니다.") String email,
+public record VolunteerSignUpRequest(Boolean isOptionAgr,
+                                     @NotBlank(message = "이름은 필수 입력 값입니다.")
+                                     String name,
+                                     @NotBlank(message = "휴대전화 번호는 필수 입력 값입니다.")
+                                     @Pattern(regexp = "^010[0-9]{8}$", message = "유효하지 않은 휴대전화 번호입니다.")
+                                     String phone,
+                                     @Email(message="이메일 형식에 맞지 않습니다.")
+                                     @NotBlank(message = "이메일은 필수 입력 값입니다.")
+                                     String email,
                                      @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d).{10,}$|^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[~!@#$%^&*()+|=?]).{8,}$",
-                                             message = "영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상을 입력해 주세요.") String password,
+                                             message = "영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상을 입력해 주세요.")
+                                     String password,
                                      @Pattern(regexp = "^[가-힣0-9]*$", message = "닉네임은 한글, 숫자만 사용 가능합니다.")
                                      @NotBlank(message = "닉네임은 필수 입력 값입니다.")
                                      @Size(min=2, max=10, message = "닉네임은 2~10자로 입력해 주세요.")
                                      String nickname,
-                                     Integer profileImageNum,
-                                     Boolean isOptionAgr) {
+                                     Integer profileImageNum) {
 
     public Volunteer toEntity() {
         return Volunteer.builder()
+                .isOptionAgr(isOptionAgr)
+                .name(name)
+                .phone(phone)
                 .email(email)
                 .password(password)
                 .nickname(nickname)
                 .profileImageNum(profileImageNum)
-                .isOptionAgr(isOptionAgr)
                 .notification(true)
-                .role(VolunteerRole.VOLUNTEER)
+                .role(VolunteerRole.AUTH_VOLUNTEER)
                 .build();
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
@@ -41,6 +41,9 @@ public class AuthService {
 
     public void volunteerSignUp(VolunteerSignUpRequest request) {
 
+        if (volunteerRepository.existsByPhone(request.phone())) {
+            throw new BadRequestException(ALREADY_EXIST_PHONE);
+        }
         if (volunteerRepository.existsByEmail(request.email())) {
             throw new BadRequestException(ALREADY_EXIST_EMAIL);
         }

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
@@ -61,6 +61,9 @@ public class AuthService {
 
     public void intermediarySignUp(IntermediarySignUpRequest request, MultipartFile authFile, MultipartFile profileFile) {
 
+        if (intermediaryRepository.existsByPhone(request.phone())) {
+            throw new BadRequestException(ALREADY_EXIST_PHONE);
+        }
         if (intermediaryRepository.existsByEmail(request.email())) {
             throw new BadRequestException(ALREADY_EXIST_EMAIL);
         }

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/entity/Intermediary.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/entity/Intermediary.java
@@ -30,9 +30,14 @@ public class Intermediary extends BaseTimeEntity {
     private Boolean notification;   // 알림 true, false
     @Column(length = 200)
     private String guide; // 안내사항 (프로필 수정에서 입력)
+    @Column(length = 10)
+    private String realName;
+    private String phone;
 
     @Builder
-    public Intermediary(String email, String password, String name, String url, String authImage, String profileImage, String intro, String contact, IntermediaryRole role, Boolean isOptionAgr, Boolean notification) {
+    public Intermediary(String realName, String phone, String email, String password, String name, String url, String authImage, String profileImage, String intro, String contact, IntermediaryRole role, Boolean isOptionAgr, Boolean notification) {
+        this.realName = realName;
+        this.phone = phone;
         this.email = email;
         this.password = password;
         this.name = name;

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/repository/IntermediaryRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/repository/IntermediaryRepository.java
@@ -11,4 +11,5 @@ public interface IntermediaryRepository extends JpaRepository<Intermediary, Long
     Boolean existsByEmail(String email);
     Boolean existsByName(String name);
     Optional<Intermediary> findByEmail(String email);
+    Boolean existsByPhone(String phone);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
@@ -31,13 +31,15 @@ public class Volunteer extends BaseTimeEntity {
     private Boolean notification;   // 알림 true, false
 
     @Builder
-    public Volunteer(String email, String password, String nickname, Integer profileImageNum, VolunteerRole role, Boolean isOptionAgr, Boolean notification) {
+    public Volunteer(Boolean isOptionAgr, String name, String phone, String email, String password, String nickname, Integer profileImageNum, VolunteerRole role, Boolean notification) {
+        this.isOptionAgr = isOptionAgr;
+        this.name = name;
+        this.phone = phone;
         this.email = email;
         this.password = password;
         this.nickname = nickname;
         this.profileImageNum = profileImageNum;
         this.role = role;
-        this.isOptionAgr = isOptionAgr;
         this.notification = notification;
     }
 

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/repository/VolunteerRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/repository/VolunteerRepository.java
@@ -13,5 +13,6 @@ public interface VolunteerRepository extends JpaRepository<Volunteer, Long> {
     Boolean existsByEmail(String email);
     Boolean existsByNickname(String nickname);
     Optional<Volunteer> findByEmail(String email);
+    Boolean existsByPhone(String phone);
 
 }

--- a/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
+++ b/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     UNKNOWN_PROVIDER("A5", "provider 값이 KAKAO 또는 NAVER가 아닙니다."),
     NOT_ALLOWED_MEMBER("A6", "해당 요청에 대한 권한이 없습니다."),
     NOT_AUTHENTICATED_REQUEST("A7", "유효한 JWT 토큰이 없습니다."),
+    ALREADY_EXIST_PHONE("A8", "이미 등록된 전화번호입니다."),
 
 
     VOLUNTEER_NOT_FOUND("M1", "해당 이동봉사자를 찾을 수 없습니다."), // Member -> M (이동봉사자, 이동봉사 중개 통일)

--- a/src/test/java/com/pawwithu/connectdog/domain/auth/controller/SignUpControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/auth/controller/SignUpControllerTest.java
@@ -71,11 +71,8 @@ class SignUpControllerTest {
     @Test
     void 이동봉사자_자체_회원가입() throws Exception{
         //given
-        VolunteerSignUpRequest request = new VolunteerSignUpRequest("email@naver.com",
-                "pasword12345",
-                "코넥독",
-                3,
-                false);
+        VolunteerSignUpRequest request = new VolunteerSignUpRequest(true, "한호정", "01011112222",
+                "email@naver.com", "pasword12345", "코넥독", 3);
         //when
         ResultActions result = mockMvc.perform(
                 post("/volunteers/sign-up")
@@ -90,13 +87,12 @@ class SignUpControllerTest {
     @Test
     void 이동봉사_중개_자체_회원가입() throws Exception{
         //given
-        IntermediarySignUpRequest request = new IntermediarySignUpRequest("email@naver.com",
+        IntermediarySignUpRequest request = new IntermediarySignUpRequest(true, "한호정", "01011112222", "email@naver.com",
                 "pasword12345",
                 "이동봉사 단체",
-                "https://connectdog.site",
                 "안녕하세요 코넥독입니다.",
-                "인스타그램",
-                false);
+                "https://connectdog.site",
+                "인스타그램");
 
         MockMultipartFile authImage = new MockMultipartFile("authImage", "authImage.png", "multipart/form-data", "uploadFile".getBytes(StandardCharsets.UTF_8));
         MockMultipartFile profileImage = new MockMultipartFile("profileImage", "profileImage.png", "multipart/form-data", "uploadFile".getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
## 💡 연관된 이슈
close #165 

## 📝 작업 내용
 - 이동봉사자, 모집자 자체 회원가입 API 수정
 - 모집자 이름, 전화번호 필드 추가
 - 이동봉사자, 모집자 자체 회원가입 테스트 코드 수정

## 💬 리뷰 요구 사항
- 이전에 모집자명의 필드를 name으로 설정해서 이름과 전화번호 필드를 추가하기 위해서는 name -> nickname으로 변환하는 작업이 필요함
- 하지만 현재 name을 이동봉사자도 쓰고 있어 Find and Replace로 한 번에 nickname으로 변경한다면 예상치 못한 오류 발생 가능성이 있음 -> 현행 유지 결정
- 현재 개발 건에서 추가한 모집자의 이름과 전화번호가 실제로 사용되는 곳은 많지 않다고 판단되어, name(모집자명)과 구분하여 realName(이름)으로 필드를 추가함 (전화번호는 phone)
