### PR TITLE
[Feature] 이동봉사 후기 조회 API 추가 수정

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryController.java
@@ -71,17 +71,29 @@ public class IntermediaryController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "중개 프로필 - 후기 조회", description = "중개 프로필에서 후기를 조회합니다.",
+    @Operation(summary = "이동봉사자 - 중개 프로필 - 후기 조회", description = "중개 프로필에서 후기를 조회합니다.",
             security = { @SecurityRequirement(name = "bearer-key") },
             responses = {@ApiResponse(responseCode = "200", description = "중개 프로필 후기 조회 성공")
                     , @ApiResponse(responseCode = "400"
                     , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
-    @GetMapping(value = {"/volunteers/intermediaries/{intermediaryId}/reviews", "/intermediaries/{intermediaryId}/reviews"})
-    public ResponseEntity<List<IntermediaryGetReviewsResponse>> getIntermediaryReviews(@PathVariable Long intermediaryId,
-                                                                                       Pageable pageable) {
-        List<IntermediaryGetReviewsResponse> response = intermediaryService.getIntermediaryReviews(intermediaryId, pageable);
+    @GetMapping("/volunteers/intermediaries/{intermediaryId}/reviews")
+    public ResponseEntity<List<IntermediaryGetReviewsResponse>> volunteerGetIntermediaryReviews(@PathVariable Long intermediaryId, Pageable pageable) {
+        List<IntermediaryGetReviewsResponse> response = intermediaryService.volunteerGetIntermediaryReviews(intermediaryId, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "모집자 - 중개 프로필 - 후기 조회", description = "중개 프로필에서 후기를 조회합니다.",
+            security = { @SecurityRequirement(name = "bearer-key") },
+            responses = {@ApiResponse(responseCode = "200", description = "중개 프로필 후기 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping("/intermediaries/reviews")
+    public ResponseEntity<List<IntermediaryGetReviewsResponse>> intermediaryGetIntermediaryReviews(@AuthenticationPrincipal UserDetails loginUser, Pageable pageable) {
+        List<IntermediaryGetReviewsResponse> response = intermediaryService.intermediaryGetIntermediaryReviews(loginUser.getUsername(), pageable);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/response/IntermediaryGetReviewsResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/response/IntermediaryGetReviewsResponse.java
@@ -7,7 +7,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record IntermediaryGetReviewsResponse(Integer profileImageNum, String dogName, String volunteerNickname,
+public record IntermediaryGetReviewsResponse(Long reviewId, Integer profileImageNum, String dogName, String volunteerNickname,
                                              @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                              LocalDate createdDate,
                                              String mainImage, List<String> images, String content,
@@ -21,17 +21,17 @@ public record IntermediaryGetReviewsResponse(Integer profileImageNum, String dog
 ) {
 
     // 후기 이미지 리스트 필드를 제외한 생성자
-    public IntermediaryGetReviewsResponse(Integer profileImageNum, String dogName, String volunteerNickname, LocalDateTime createdDate,
+    public IntermediaryGetReviewsResponse(Long reviewId, Integer profileImageNum, String dogName, String volunteerNickname, LocalDateTime createdDate,
                                 String mainImage, String content,
                                 Long postId, String postMainImage, LocalDate startDate, LocalDate endDate, String departureLoc, String arrivalLoc,
                                 Long intermediaryId, String intermediaryName) {
-        this(profileImageNum, dogName, volunteerNickname, createdDate.toLocalDate(), mainImage, null, content,
+        this(reviewId, profileImageNum, dogName, volunteerNickname, createdDate.toLocalDate(), mainImage, null, content,
                 postId, postMainImage, startDate, endDate, departureLoc, arrivalLoc, intermediaryId, intermediaryName);
     }
 
     // 후기 이미지 리스트 필드를 포함한 생성자
     public static IntermediaryGetReviewsResponse of(IntermediaryGetReviewsResponse response, List<String> images) {
-        return new IntermediaryGetReviewsResponse(response.profileImageNum, response.dogName, response.volunteerNickname, response.createdDate,
+        return new IntermediaryGetReviewsResponse(response.reviewId, response.profileImageNum, response.dogName, response.volunteerNickname, response.createdDate,
                 response.mainImage, images, response.content,
                 response.postId, response.postMainImage, response.startDate, response.endDate, response.departureLoc, response.arrivalLoc, response.intermediaryId, response.intermediaryName);
     }

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
@@ -8,6 +8,7 @@ import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
 import com.pawwithu.connectdog.domain.post.entity.PostStatus;
 import com.pawwithu.connectdog.domain.post.repository.CustomPostRepository;
+import com.pawwithu.connectdog.domain.review.dto.response.ReviewGetAllResponse;
 import com.pawwithu.connectdog.domain.review.repository.CustomReviewRepository;
 import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -66,8 +68,20 @@ public class IntermediaryService {
         if (!intermediaryRepository.existsById(intermediaryId)){
             throw new BadRequestException(INTERMEDIARY_NOT_FOUND);
         }
-        List<IntermediaryGetReviewsResponse> intermediaryReviews = customReviewRepository.getIntermediaryReviews(intermediaryId, pageable);
-        return intermediaryReviews;
+
+        List<IntermediaryGetReviewsResponse> resultReviews = new ArrayList<>();
+
+        // 후기 조회 (대표 이미지 포함)
+        List<IntermediaryGetReviewsResponse> reviews = customReviewRepository.getIntermediaryReviews(intermediaryId, pageable);
+
+        for (IntermediaryGetReviewsResponse intermediaryGetReviewsResponse : reviews) {
+            // 후기 이미지 조회 (대표 이미지 제외)
+            List<String> oneReviewImages = customReviewRepository.getOneReviewImages(intermediaryGetReviewsResponse.reviewId());
+            IntermediaryGetReviewsResponse review = IntermediaryGetReviewsResponse.of(intermediaryGetReviewsResponse, oneReviewImages);
+            resultReviews.add(review);
+        }
+
+        return resultReviews;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
@@ -8,7 +8,6 @@ import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
 import com.pawwithu.connectdog.domain.post.entity.PostStatus;
 import com.pawwithu.connectdog.domain.post.repository.CustomPostRepository;
-import com.pawwithu.connectdog.domain.review.dto.response.ReviewGetAllResponse;
 import com.pawwithu.connectdog.domain.review.repository.CustomReviewRepository;
 import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
 import lombok.RequiredArgsConstructor;
@@ -39,7 +38,7 @@ public class IntermediaryService {
     @Transactional(readOnly = true)
     public List<IntermediaryGetPostsResponse> volunteerGetIntermediaryPosts(Long intermediaryId, String orderCondition, Pageable pageable) {
         // 이동봉사 중개
-        if (!intermediaryRepository.existsById(intermediaryId)){
+        if (!intermediaryRepository.existsById(intermediaryId)) {
             throw new BadRequestException(INTERMEDIARY_NOT_FOUND);
         }
         List<IntermediaryGetPostsResponse> intermediaryPosts = customPostRepository.getIntermediaryPosts(intermediaryId, orderCondition, pageable);
@@ -50,7 +49,7 @@ public class IntermediaryService {
     public IntermediaryGetInfoResponse getIntermediaryInfo(Long intermediaryId) {
         Intermediary intermediary = intermediaryRepository.findById(intermediaryId).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
         // 봉사 완료 건수
-        Long completedPostCount =  customPostRepository.getCountOfCompletedPosts(intermediaryId);
+        Long completedPostCount = customPostRepository.getCountOfCompletedPosts(intermediaryId);
 
         // 받은 후기 총 건수
         Long reviewCount = customReviewRepository.getIntermediaryCountOfReviews(intermediaryId);
@@ -63,9 +62,9 @@ public class IntermediaryService {
     }
 
     @Transactional(readOnly = true)
-    public List<IntermediaryGetReviewsResponse> getIntermediaryReviews(Long intermediaryId, Pageable pageable) {
+    public List<IntermediaryGetReviewsResponse> volunteerGetIntermediaryReviews(Long intermediaryId, Pageable pageable) {
         // 이동봉사 중개
-        if (!intermediaryRepository.existsById(intermediaryId)){
+        if (!intermediaryRepository.existsById(intermediaryId)) {
             throw new BadRequestException(INTERMEDIARY_NOT_FOUND);
         }
 
@@ -85,9 +84,27 @@ public class IntermediaryService {
     }
 
     @Transactional(readOnly = true)
+    public List<IntermediaryGetReviewsResponse> intermediaryGetIntermediaryReviews(String email, Pageable pageable) {
+        Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
+        List<IntermediaryGetReviewsResponse> resultReviews = new ArrayList<>();
+
+        // 후기 조회 (대표 이미지 포함)
+        List<IntermediaryGetReviewsResponse> reviews = customReviewRepository.getIntermediaryReviews(intermediary.getId(), pageable);
+
+        for (IntermediaryGetReviewsResponse intermediaryGetReviewsResponse : reviews) {
+            // 후기 이미지 조회 (대표 이미지 제외)
+            List<String> oneReviewImages = customReviewRepository.getOneReviewImages(intermediaryGetReviewsResponse.reviewId());
+            IntermediaryGetReviewsResponse review = IntermediaryGetReviewsResponse.of(intermediaryGetReviewsResponse, oneReviewImages);
+            resultReviews.add(review);
+        }
+
+        return resultReviews;
+    }
+
+    @Transactional(readOnly = true)
     public List<IntermediaryGetDogStatusesResponse> getIntermediaryDogStatuses(Long intermediaryId, Pageable pageable) {
         // 이동봉사 중개
-        if (!intermediaryRepository.existsById(intermediaryId)){
+        if (!intermediaryRepository.existsById(intermediaryId)) {
             throw new BadRequestException(INTERMEDIARY_NOT_FOUND);
         }
         List<IntermediaryGetDogStatusesResponse> intermediaryDogStatuses = customDogStatusRepository.getIntermediaryDogStatuses(intermediaryId, pageable);

--- a/src/main/java/com/pawwithu/connectdog/domain/review/dto/response/ReviewGetAllResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/dto/response/ReviewGetAllResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record ReviewGetAllResponse(Integer profileImageNum, String dogName, String volunteerNickname,
+public record ReviewGetAllResponse(Long reviewId, Integer profileImageNum, String dogName, String volunteerNickname,
                                    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
                                    LocalDate createdDate,
                                    String mainImage, List<String> images, String content,
@@ -20,17 +20,17 @@ public record ReviewGetAllResponse(Integer profileImageNum, String dogName, Stri
 ) {
 
     // 후기 이미지 리스트 필드를 제외한 생성자
-    public ReviewGetAllResponse(Integer profileImageNum, String dogName, String volunteerNickname, LocalDateTime createdDate,
+    public ReviewGetAllResponse(Long reviewId, Integer profileImageNum, String dogName, String volunteerNickname, LocalDateTime createdDate,
                                 String mainImage, String content,
                                 Long postId, String postMainImage, LocalDate startDate, LocalDate endDate, String departureLoc, String arrivalLoc,
                                 Long intermediaryId, String intermediaryName) {
-        this(profileImageNum, dogName, volunteerNickname, createdDate.toLocalDate(), mainImage, null, content,
+        this(reviewId, profileImageNum, dogName, volunteerNickname, createdDate.toLocalDate(), mainImage, null, content,
                 postId, postMainImage, startDate, endDate, departureLoc, arrivalLoc, intermediaryId, intermediaryName);
     }
 
     // 후기 이미지 리스트 필드를 포함한 생성자
     public static ReviewGetAllResponse of(ReviewGetAllResponse response, List<String> images) {
-        return new ReviewGetAllResponse(response.profileImageNum, response.dogName, response.volunteerNickname, response.createdDate,
+        return new ReviewGetAllResponse(response.reviewId, response.profileImageNum, response.dogName, response.volunteerNickname, response.createdDate,
                 response.mainImage, images, response.content,
                 response.postId, response.postMainImage, response.startDate, response.endDate, response.departureLoc, response.arrivalLoc, response.intermediaryId, response.intermediaryName);
     }

--- a/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.pawwithu.connectdog.domain.review.dto.response.ReviewGetAllResponse;
 import com.pawwithu.connectdog.domain.review.dto.response.ReviewGetOneResponse;
 import com.pawwithu.connectdog.domain.review.repository.CustomReviewRepository;
 import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,7 +65,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
     public List<ReviewGetAllResponse> getAllReviews(Pageable pageable) {
         List<ReviewGetAllResponse> reviews = queryFactory
                 .select(Projections.constructor(ReviewGetAllResponse.class,
-                        volunteer.profileImageNum, dog.name, volunteer.nickname, review.createdDate,
+                        review.id, volunteer.profileImageNum, dog.name, volunteer.nickname, review.createdDate,
                         reviewImage.image, review.content,
                         post.id, post.mainImage.image, post.startDate, post.endDate, post.departureLoc, post.arrivalLoc,
                         intermediary.id, intermediary.name))

--- a/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/repository/impl/CustomReviewRepositoryImpl.java
@@ -88,7 +88,7 @@ public class CustomReviewRepositoryImpl implements CustomReviewRepository {
     public List<IntermediaryGetReviewsResponse> getIntermediaryReviews(Long intermediaryId, Pageable pageable) {
         List<IntermediaryGetReviewsResponse> reviews = queryFactory
                 .select(Projections.constructor(IntermediaryGetReviewsResponse.class,
-                        volunteer.profileImageNum, dog.name, volunteer.nickname, review.createdDate,
+                        review.id, volunteer.profileImageNum, dog.name, volunteer.nickname, review.createdDate,
                         reviewImage.image, review.content,
                         post.id, post.mainImage.image, post.startDate, post.endDate, post.departureLoc, post.arrivalLoc,
                         intermediary.id, intermediary.name))

--- a/src/main/java/com/pawwithu/connectdog/domain/review/service/ReviewService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/service/ReviewService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -89,7 +90,18 @@ public class ReviewService {
 
     @Transactional(readOnly = true)
     public List<ReviewGetAllResponse> getAllReviews(Pageable pageable) {
+        List<ReviewGetAllResponse> resultReviews = new ArrayList<>();
+
+        // 후기 조회 (대표 이미지 포함)
         List<ReviewGetAllResponse> reviews = customReviewRepository.getAllReviews(pageable);
-        return reviews;
+
+        for (ReviewGetAllResponse reviewGetAllResponse : reviews) {
+            // 후기 이미지 조회 (대표 이미지 제외)
+            List<String> oneReviewImages = customReviewRepository.getOneReviewImages(reviewGetAllResponse.reviewId());
+            ReviewGetAllResponse review = ReviewGetAllResponse.of(reviewGetAllResponse, oneReviewImages);
+            resultReviews.add(review);
+        }
+
+        return resultReviews;
     }
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
@@ -130,6 +130,7 @@ class IntermediaryControllerTest {
     void 이동봉사_중개_프로필_후기_조회() throws Exception {
         // given
         Long intermediaryId = 1L;
+        Long reviewId = 2L;
         Long postId = 3L;
         LocalDate createdDate = LocalDateTime.of(2023, 10, 31, 0, 0, 0).toLocalDate();
         List<IntermediaryGetReviewsResponse> response = new ArrayList<>();
@@ -140,10 +141,10 @@ class IntermediaryControllerTest {
         images.add("image1");
         images.add("image2");
 
-        response.add(new IntermediaryGetReviewsResponse(1, "봄이", "호짱", createdDate,
+        response.add(new IntermediaryGetReviewsResponse(reviewId, 1, "봄이", "호짱", createdDate,
                 "mainImage", images,  "후기 조회 테스트입니다.", postId, "postMainImage",
                 startDate, endDate, "서울시 노원구", "서울시 성북구", intermediaryId, "이동봉사 중개"));
-        response.add(new IntermediaryGetReviewsResponse(2, "겨울이", "호짱", createdDate,
+        response.add(new IntermediaryGetReviewsResponse(reviewId, 2, "겨울이", "호짱", createdDate,
                 "mainImage", images,  "후기 조회 테스트입니다.", postId, "postMainImage",
                 startDate, endDate, "서울시 노원구", "서울시 성북구", intermediaryId, "이동봉사 중개"));
 

--- a/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
@@ -127,7 +127,7 @@ class IntermediaryControllerTest {
     }
 
     @Test
-    void 이동봉사_중개_프로필_후기_조회() throws Exception {
+    void 이동봉사자_중개_프로필_후기_조회() throws Exception {
         // given
         Long intermediaryId = 1L;
         Long reviewId = 2L;
@@ -149,7 +149,7 @@ class IntermediaryControllerTest {
                 startDate, endDate, "서울시 노원구", "서울시 성북구", intermediaryId, "이동봉사 중개"));
 
         // when
-        given(intermediaryService.getIntermediaryReviews(anyLong(), any())).willReturn(response);
+        given(intermediaryService.volunteerGetIntermediaryReviews(anyLong(), any())).willReturn(response);
         ResultActions result = mockMvc.perform(
                 get("/volunteers/intermediaries/{intermediaryId}/reviews", intermediaryId)
                         .param("page", "0")
@@ -158,7 +158,42 @@ class IntermediaryControllerTest {
 
         // then
         result.andExpect(status().isOk());
-        verify(intermediaryService, times(1)).getIntermediaryReviews(anyLong(), any());
+        verify(intermediaryService, times(1)).volunteerGetIntermediaryReviews(anyLong(), any());
+    }
+
+    @Test
+    void 모집자_중개_프로필_후기_조회() throws Exception {
+        // given
+        Long intermediaryId = 1L;
+        Long reviewId = 2L;
+        Long postId = 3L;
+        LocalDate createdDate = LocalDateTime.of(2023, 10, 31, 0, 0, 0).toLocalDate();
+        List<IntermediaryGetReviewsResponse> response = new ArrayList<>();
+        LocalDate startDate = LocalDate.of(2023, 10, 2);
+        LocalDate endDate = LocalDate.of(2023, 11, 7);
+
+        List<String> images = new ArrayList<>();
+        images.add("image1");
+        images.add("image2");
+
+        response.add(new IntermediaryGetReviewsResponse(reviewId, 1, "봄이", "호짱", createdDate,
+                "mainImage", images,  "후기 조회 테스트입니다.", postId, "postMainImage",
+                startDate, endDate, "서울시 노원구", "서울시 성북구", intermediaryId, "이동봉사 중개"));
+        response.add(new IntermediaryGetReviewsResponse(reviewId, 2, "겨울이", "호짱", createdDate,
+                "mainImage", images,  "후기 조회 테스트입니다.", postId, "postMainImage",
+                startDate, endDate, "서울시 노원구", "서울시 성북구", intermediaryId, "이동봉사 중개"));
+
+        // when
+        given(intermediaryService.intermediaryGetIntermediaryReviews(anyString(), any())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/intermediaries/reviews", intermediaryId)
+                        .param("page", "0")
+                        .param("size", "2")
+        );
+
+        // then
+        result.andExpect(status().isOk());
+        verify(intermediaryService, times(1)).intermediaryGetIntermediaryReviews(anyString(), any());
     }
 
     @Test

--- a/src/test/java/com/pawwithu/connectdog/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/review/controller/ReviewControllerTest.java
@@ -108,6 +108,7 @@ class ReviewControllerTest {
     void 후기_전체_조회() throws Exception {
         // given
         List<ReviewGetAllResponse> response = new ArrayList<>();
+        Long reviewId = 1L;
         Long intermediaryId = 2L;
         Long postId = 3L;
         LocalDate createdDate = LocalDateTime.of(2023, 10, 31, 0, 0, 0).toLocalDate();
@@ -118,10 +119,10 @@ class ReviewControllerTest {
         images.add("image1");
         images.add("image2");
 
-        response.add(new ReviewGetAllResponse(1, "봄이", "호짱", createdDate,
+        response.add(new ReviewGetAllResponse(reviewId, 1, "봄이", "호짱", createdDate,
                 "mainImage", images,  "후기 조회 테스트입니다.", postId, "postMainImage",
                 startDate, endDate, "서울시 노원구", "서울시 성북구", intermediaryId, "이동봉사 중개"));
-        response.add(new ReviewGetAllResponse(2, "겨울이", "호짱", createdDate,
+        response.add(new ReviewGetAllResponse(reviewId, 2, "겨울이", "호짱", createdDate,
                 "mainImage", images,  "후기 조회 테스트입니다.", postId, "postMainImage",
                 startDate, endDate, "서울시 노원구", "서울시 성북구", intermediaryId, "이동봉사 중개"));
 


### PR DESCRIPTION
## 💡 연관된 이슈
close #174 

## 📝 작업 내용
- 봉사자 - 후기 전체 조회 API 반환값 수정 (후기 아이디 추가) & 대표 이미지를 제외한 후기 이미지 매핑
-  봉사자 - 모집자 프로필 - 후기 조회 API 반환값 수정 (후기 아이디 추가) & 대표 이미지를 제외한 후기 이미지 매핑
<br>

- 모집자 - 모집자 프로필 - 후기 조회 API uri 분리
- 모집자 - 모집자 프로필 - 후기 조회 API 테스트 코드 작성

## 💬 리뷰 요구 사항
대표 이미지를 제외한 후기 이미지 배열을 매핑할 때, 처음에는 하나의 쿼리로 날리고 싶었지만 queryDsl 서브쿼리에서 배열을 가져와 필드 하나에 매핑하는 게 불가능해서 -> 기존에 사용하던 쿼리 메서드를 이용해 service 단에서 결과 배열을 새로 만들었습니다. 

결과적으로 실행되는 쿼리 수는 동일하고, for문 안에서 돌아가는 쿼리가 이미지 배열을 불러오는 쿼리이기에 메모리 사용량이 크지 않아서 괜찮을 것 같다고 생각했는데 혹시 더 좋은 방안이 있다면 남겨주세요!
