### PR TITLE
[Feature] 이동봉사자 마이페이지 메인 정보 조회 API 수정 

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/CustomApplicationRepository.java
@@ -3,6 +3,7 @@ package com.pawwithu.connectdog.domain.application.repository;
 import com.pawwithu.connectdog.domain.application.dto.response.*;
 import com.pawwithu.connectdog.domain.application.entity.Application;
 import com.pawwithu.connectdog.domain.application.entity.ApplicationStatus;
+import com.querydsl.core.Tuple;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -18,8 +19,6 @@ public interface CustomApplicationRepository {
     List<ApplicationIntermediaryProgressingResponse> getIntermediaryProgressingApplications(Long intermediaryId, Pageable pageable);
     List<ApplicationVolunteerCompletedResponse> getVolunteerCompletedApplications(Long volunteerId, Pageable pageable);
     List<ApplicationIntermediaryCompletedResponse> getIntermediaryCompletedApplications(Long intermediaryId, Pageable pageable);
-
-    // 진행한 이동봉사 건수
-    Long getCountOfCompletedApplications(Long id);
+    List<Tuple> getCountOfApplicationsByStatus(Long id);
     boolean existsByPostIdAndPostStatus(Long postId);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/impl/CustomApplicationRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.pawwithu.connectdog.domain.application.dto.response.*;
 import com.pawwithu.connectdog.domain.application.entity.Application;
 import com.pawwithu.connectdog.domain.application.entity.ApplicationStatus;
 import com.pawwithu.connectdog.domain.application.repository.CustomApplicationRepository;
+import com.querydsl.core.Tuple;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
@@ -170,15 +171,14 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
                 .fetch();
     }
 
-    // 진행한 이동봉사 건수
     @Override
-    public Long getCountOfCompletedApplications(Long id) {
+    public List<Tuple> getCountOfApplicationsByStatus(Long id) {
         return queryFactory
-                .select(application.count())
+                .select(application.status, application.count())
                 .from(application)
-                .where(application.volunteer.id.eq(id)
-                        .and(application.status.eq(ApplicationStatus.COMPLETED)))
-                .fetchOne();
+                .where(application.volunteer.id.eq(id))
+                .groupBy(application.status)
+                .fetch();
     }
 
     @Override
@@ -190,4 +190,5 @@ public class CustomApplicationRepositoryImpl implements CustomApplicationReposit
                         .and(application.status.ne(ApplicationStatus.REJECTED)))
                 .fetchOne() != null;
     }
+
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerController.java
@@ -53,7 +53,7 @@ public class VolunteerController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "마이페이지 기본 정보 조회 API", description = "마이페이지 기본 정보를 조회합니다.",
+    @Operation(summary = "마이페이지 메인 정보 조회 API", description = "마이페이지 메인 화면의 닉네임, 프로필 이미지, 봉사 현황 요약 조회를 조회합니다.",
             responses = {@ApiResponse(responseCode = "200", description = "마이페이지 기본 정보 조회 성공")
                     , @ApiResponse(responseCode = "400"
                     , description = "M1, 해당 이동봉사자를 찾을 수 없습니다."

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/response/VolunteerGetMyInfoResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/response/VolunteerGetMyInfoResponse.java
@@ -1,7 +1,10 @@
 package com.pawwithu.connectdog.domain.volunteer.dto.response;
 
-public record VolunteerGetMyInfoResponse(Integer profileImageNum, String nickname, Long completedCount, Long reviewCount, Long dogStatusCount) {
-    public static VolunteerGetMyInfoResponse of(Integer profileImageNum, String nickname, Long completedCount, Long reviewCount, Long dogStatusCount) {
-        return new VolunteerGetMyInfoResponse(profileImageNum, nickname, completedCount, reviewCount, dogStatusCount);
+public record VolunteerGetMyInfoResponse(Integer profileImageNum, String nickname,
+                                         Long waitingCount, Long progressingCount, Long completedCount, Long reviewCount) {
+
+    public static VolunteerGetMyInfoResponse of(Integer profileImageNum, String nickname,
+                                                Long waitingCount, Long progressingCount, Long completedCount, Long reviewCount) {
+        return new VolunteerGetMyInfoResponse(profileImageNum, nickname, waitingCount, progressingCount, completedCount, reviewCount);
     }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/service/VolunteerService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/service/VolunteerService.java
@@ -1,5 +1,6 @@
 package com.pawwithu.connectdog.domain.volunteer.service;
 
+import com.pawwithu.connectdog.domain.application.entity.ApplicationStatus;
 import com.pawwithu.connectdog.domain.application.repository.CustomApplicationRepository;
 import com.pawwithu.connectdog.domain.badge.repository.CustomVolunteerBadgeRepository;
 import com.pawwithu.connectdog.domain.bookmark.repository.CustomBookmarkRepository;
@@ -13,6 +14,7 @@ import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import com.pawwithu.connectdog.domain.volunteer.repository.VolunteerRepository;
 import com.pawwithu.connectdog.error.ErrorCode;
 import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
+import com.querydsl.core.Tuple;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -21,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.pawwithu.connectdog.domain.application.entity.QApplication.application;
 import static com.pawwithu.connectdog.error.ErrorCode.ALREADY_EXIST_NICKNAME;
 import static com.pawwithu.connectdog.error.ErrorCode.VOLUNTEER_NOT_FOUND;
 
@@ -54,16 +57,25 @@ public class VolunteerService {
     public VolunteerGetMyInfoResponse getMyInfo(String email) {
         Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
 
-        // 진행한 이동봉사 건수
-        Long completedCount = customApplicationRepository.getCountOfCompletedApplications(volunteer.getId());
-
-        // 봉사 후기 건수
+        Long waitingCount = 0L;
+        Long progressingCount = 0L;
+        Long completedCount = 0L;
         Long reviewCount = customReviewRepository.getVolunteerCountOfReviews(volunteer.getId());
 
-        // 입양 근황 건수
-        Long dogStatusCount = customDogStatusRepository.getVolunteerCountOfDogStatuses(volunteer.getId());
+        List<Tuple> applicationCounts = customApplicationRepository.getCountOfApplicationsByStatus(volunteer.getId());
+        for (Tuple tuple : applicationCounts) {
+            ApplicationStatus status = tuple.get(application.status);
+            Long count = tuple.get(application.count());
 
-        VolunteerGetMyInfoResponse response = VolunteerGetMyInfoResponse.of(volunteer.getProfileImageNum(), volunteer.getNickname(), completedCount, reviewCount, dogStatusCount);
+            switch (status) {
+                case WAITING -> waitingCount = count;
+                case PROGRESSING -> progressingCount = count;
+                case COMPLETED -> completedCount = count;
+            }
+        }
+
+        VolunteerGetMyInfoResponse response = VolunteerGetMyInfoResponse.of(volunteer.getProfileImageNum(), volunteer.getNickname(),
+                waitingCount, progressingCount, completedCount, reviewCount);
         return response;
     }
 

--- a/src/test/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerControllerTest.java
@@ -92,7 +92,7 @@ class VolunteerControllerTest {
     @Test
     void 이동봉사자_마이페이지_기본_정보_조회() throws Exception {
         // given
-        VolunteerGetMyInfoResponse response = VolunteerGetMyInfoResponse.of(1, "하노정", 1L, 3L, 5L);
+        VolunteerGetMyInfoResponse response = VolunteerGetMyInfoResponse.of(1, "하노정", 1L, 3L, 5L, 4L);
 
         // when
         given(volunteerService.getMyInfo(any())).willReturn(response);


### PR DESCRIPTION
## 💡 연관된 이슈
close #181 

## 📝 작업 내용
- 이동봉사자 마이페이지 메인 정보 조회 API 반환값 수정 (승인 대기중/진행중인 건수 추가, 근황 건수 제거)
- 이동봉사자 마이페이지 메인 정보 조회 API 테스트 코드 수정

## 💬 리뷰 요구 사항