### PR TITLE
[Feature] 봉사자 공고 관련 API 수정

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/controller/ApplicationController.java
@@ -31,7 +31,7 @@ public class ApplicationController {
             security = { @SecurityRequirement(name = "bearer-key") },
             responses = {@ApiResponse(responseCode = "204", description = "이동봉사자 소셜 로그인 추가 회원가입 성공")
                     , @ApiResponse(responseCode = "400"
-                    , description = "V1, 이름은 필수 입력 값입니다. \t\n V1, 휴대전화 번호는 필수 입력 값입니다. \t\n V1, 유효하지 않은 휴대전화 번호입니다. \t\n " +
+                    , description = "V1, 이름은 필수 입력 값입니다. \t\n V1, 한글만 입력 가능합니다. \t\n V1, 휴대전화 번호는 필수 입력 값입니다. \t\n V1, 유효하지 않은 휴대전화 번호입니다. \t\n " +
                     "V1, 100자 이내로 입력해 주세요. \t\n M1, 해당 이동봉사자를 찾을 수 없습니다. \t\n P2, 해당 공고를 찾을 수 없습니다. \t\n AP1, 이미 신청된 공고입니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })

--- a/src/main/java/com/pawwithu/connectdog/domain/application/dto/request/VolunteerApplyRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/dto/request/VolunteerApplyRequest.java
@@ -11,6 +11,7 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record VolunteerApplyRequest(@NotBlank(message = "이름은 필수 입력 값입니다.")
+                                    @Pattern(regexp = "^[가-힣]*$", message = "한글만 입력 가능합니다.")
                                     String name,
                                     @NotBlank(message = "휴대전화 번호는 필수 입력 값입니다.")
                                     @Pattern(regexp = "^010[0-9]{8}$", message = "유효하지 않은 휴대전화 번호입니다.")

--- a/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/controller/PostController.java
@@ -46,8 +46,8 @@ public class PostController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "홈 화면 공고 5개 최신 순 조회", description = "홈 화면에서 공고 5개를 최신 순으로 조회합니다.",
-            responses = {@ApiResponse(responseCode = "200", description = "홈 화면 공고 5개 조회 성공")})
+    @Operation(summary = "홈 화면 공고 6개 최신 순 조회", description = "홈 화면에서 공고 6개를 최신 순으로 조회합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "홈 화면 공고 6개 조회 성공")})
     @GetMapping(value = "/volunteers/posts/home")
     public ResponseEntity<List<PostGetHomeResponse>> getHomePosts() {
         List<PostGetHomeResponse> homePosts = postService.getHomePosts();

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/CustomPostRepository.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 public interface CustomPostRepository {
 
-    // 홈 화면 공고 5개 조회
+    // 홈 화면 공고 6개 조회
     List<PostGetHomeResponse> getHomePosts();
     // 공고 필터 검색
     List<PostSearchResponse> searchPosts(PostSearchRequest request, Pageable pageable);

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
@@ -62,7 +62,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                 .join(post.dog, dog)
                 .join(post.mainImage, postImage)
                 .where(allFilterSearch(request, pageable))
-                .orderBy(createOrderSpecifierEC(request.orderCondition()))
+                .orderBy(createOrderSpecifierCE(request.orderCondition()))
                 .offset(pageable.getOffset())   // 페이지 번호
                 .limit(pageable.getPageSize())  // 페이지 사이즈
                 .fetch();
@@ -229,7 +229,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
 
     // 정렬 필터
     private OrderSpecifier[] createOrderSpecifierEC(String orderCondition) {
-        // default = 마감순 -> 최신순
+        // default = 마감 임박순 -> 최근 등록순
         OrderSpecifier[] defaultOrder = {
                 new OrderSpecifier(Order.ASC, post.endDate),
                 new OrderSpecifier(Order.DESC, post.createdDate)
@@ -238,8 +238,8 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
         // 정렬 조건 X: default
         if (!StringUtils.hasText(orderCondition))
             return defaultOrder;
-        // "최신순": 최신순 -> 마감순, 나머지: default
-        return orderCondition.equals("최신순")
+        // "최근 등록순": 최근 등록순 -> 마감 임박순, 나머지: default
+        return orderCondition.equals("최근 등록순")
                 ? new OrderSpecifier[]{
                         new OrderSpecifier(Order.DESC, post.createdDate),
                         new OrderSpecifier(Order.ASC, post.endDate)}
@@ -248,7 +248,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
 
     // 정렬 필터
     private OrderSpecifier[] createOrderSpecifierCE(String orderCondition) {
-        // default = 최신순 -> 마감순
+        // default = 최근 등록순 -> 마감 임박순
         OrderSpecifier[] defaultOrder = {
                 new OrderSpecifier(Order.DESC, post.createdDate),
                 new OrderSpecifier(Order.ASC, post.endDate)
@@ -257,8 +257,8 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
         // 정렬 조건 X: default
         if (!StringUtils.hasText(orderCondition))
             return defaultOrder;
-        // "최신순": 최신순 -> 마감순, 나머지: default
-        return orderCondition.equals("마감순")
+        // "마감 임박순": 마감 임박순 -> 최근 등록순, 나머지: default
+        return orderCondition.equals("마감 임박순")
                 ? new OrderSpecifier[]{
                 new OrderSpecifier(Order.ASC, post.endDate),
                 new OrderSpecifier(Order.DESC, post.createdDate)}

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/impl/CustomPostRepositoryImpl.java
@@ -34,7 +34,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
 
     private final JPAQueryFactory queryFactory;
 
-    // 홈 화면 공고 5개 조회
+    // 홈 화면 공고 6개 조회
     @Override
     public List<PostGetHomeResponse> getHomePosts() {
         return queryFactory
@@ -46,7 +46,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                         .join(post.dog, dog)
                         .where(post.status.eq(PostStatus.RECRUITING))
                         .orderBy(post.createdDate.desc())
-                        .limit(5)
+                        .limit(6)
                         .fetch();
     }
 


### PR DESCRIPTION
## 💡 연관된 이슈
close #185 

## 📝 작업 내용
- 봉사자 홈 화면 공고 조회 - 6개 조회로 변경
- 목록 조회 시 default: 최근 등록순으로 변경 (워딩: 최신순 -> 최근 등록순, 마감순 -> 마감 임박순)
- 공고 신청 시 Validation 추가 및 워딩 변경

## 💬 리뷰 요구 사항
와이어프레임 검토 후 변경 사항 수정합니다!