### PR TITLE
[Feature] 모집자 프로필 - 기본 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryController.java
@@ -44,14 +44,14 @@ public class IntermediaryController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "중개자 - 중개 프로필 - 이동봉사 공고 목록 조회", description = "중개 프로필에서 이동봉사 공고 목록을 조회합니다.",
+    @Operation(summary = "모집자 - 중개 프로필 - 이동봉사 공고 목록 조회", description = "중개 프로필에서 이동봉사 공고 목록을 조회합니다.",
             security = { @SecurityRequirement(name = "bearer-key") },
             responses = {@ApiResponse(responseCode = "200", description = "이동봉사 공고 목록 조회 성공")
                     , @ApiResponse(responseCode = "400"
                     , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
-    @GetMapping(value = "/intermediaries/posts")
+    @GetMapping(value = "/intermediaries/my/posts")
     public ResponseEntity<List<IntermediaryGetPostsResponse>> intermediaryGetIntermediaryPosts(@AuthenticationPrincipal UserDetails loginUser,
                                                                                    @RequestParam(required = false) String orderCondition,
                                                                                    Pageable pageable) {
@@ -79,7 +79,7 @@ public class IntermediaryController {
                     , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
-    @GetMapping("/intermediaries")
+    @GetMapping("/intermediaries/my/info")
     public ResponseEntity<IntermediaryGetInfoResponse> intermediaryGetIntermediaryInfo(@AuthenticationPrincipal UserDetails loginUser) {
         IntermediaryGetInfoResponse response = intermediaryService.intermediaryGetIntermediaryInfo(loginUser.getUsername());
         return ResponseEntity.ok(response);
@@ -105,7 +105,7 @@ public class IntermediaryController {
                     , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
-    @GetMapping("/intermediaries/reviews")
+    @GetMapping("/intermediaries/my/reviews")
     public ResponseEntity<List<IntermediaryGetReviewsResponse>> intermediaryGetIntermediaryReviews(@AuthenticationPrincipal UserDetails loginUser, Pageable pageable) {
         List<IntermediaryGetReviewsResponse> response = intermediaryService.intermediaryGetIntermediaryReviews(loginUser.getUsername(), pageable);
         return ResponseEntity.ok(response);

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryController.java
@@ -59,7 +59,7 @@ public class IntermediaryController {
         return ResponseEntity.ok(response);
     }
 
-    @Operation(summary = "중개 프로필 - 기본 정보 조회", description = "중개 프로필에서 기본 정보를 조회합니다.",
+    @Operation(summary = "이동봉사자 - 중개 프로필 - 기본 정보 조회", description = "중개 프로필에서 기본 정보를 조회합니다.",
             security = { @SecurityRequirement(name = "bearer-key") },
             responses = {@ApiResponse(responseCode = "200", description = "중개 프로필 기본 정보 조회 성공")
                     , @ApiResponse(responseCode = "400"
@@ -67,8 +67,21 @@ public class IntermediaryController {
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @GetMapping("/volunteers/intermediaries/{intermediaryId}")
-    public ResponseEntity<IntermediaryGetInfoResponse> getIntermediaryInfo(@PathVariable Long intermediaryId) {
-        IntermediaryGetInfoResponse response = intermediaryService.getIntermediaryInfo(intermediaryId);
+    public ResponseEntity<IntermediaryGetInfoResponse> volunteerGetIntermediaryInfo(@PathVariable Long intermediaryId) {
+        IntermediaryGetInfoResponse response = intermediaryService.volunteerGetIntermediaryInfo(intermediaryId);
+        return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "모집자 - 중개 프로필 - 기본 정보 조회", description = "중개 프로필에서 기본 정보를 조회합니다.",
+            security = { @SecurityRequirement(name = "bearer-key") },
+            responses = {@ApiResponse(responseCode = "200", description = "중개 프로필 기본 정보 조회 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @GetMapping("/intermediaries")
+    public ResponseEntity<IntermediaryGetInfoResponse> intermediaryGetIntermediaryInfo(@AuthenticationPrincipal UserDetails loginUser) {
+        IntermediaryGetInfoResponse response = intermediaryService.intermediaryGetIntermediaryInfo(loginUser.getUsername());
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
@@ -48,8 +48,15 @@ public class IntermediaryService {
     }
 
     @Transactional(readOnly = true)
-    public IntermediaryGetInfoResponse getIntermediaryInfo(Long intermediaryId) {
+    public IntermediaryGetInfoResponse volunteerGetIntermediaryInfo(Long intermediaryId) {
         Intermediary intermediary = intermediaryRepository.findById(intermediaryId).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
+        IntermediaryGetInfoResponse intermediaryInfo = IntermediaryGetInfoResponse.from(intermediary);
+        return intermediaryInfo;
+    }
+
+    @Transactional(readOnly = true)
+    public IntermediaryGetInfoResponse intermediaryGetIntermediaryInfo(String username) {
+        Intermediary intermediary = intermediaryRepository.findByEmail(username).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
         IntermediaryGetInfoResponse intermediaryInfo = IntermediaryGetInfoResponse.from(intermediary);
         return intermediaryInfo;
     }

--- a/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
@@ -117,15 +117,34 @@ class IntermediaryControllerTest {
                 "이동봉사 중개 이름", "안녕하세요. 한 줄 소개 입니다.", "https://connectdog.site", "인스타그램: @hoxjeong", "안내 사항입니다.");
 
         // when
-        given(intermediaryService.getIntermediaryInfo(anyLong())).willReturn(response);
+        given(intermediaryService.volunteerGetIntermediaryInfo(anyLong())).willReturn(response);
         ResultActions result = mockMvc.perform(
                 get("/volunteers/intermediaries/{intermediaryId}", intermediaryId)
         );
 
         // then
         result.andExpect(status().isOk());
-        verify(intermediaryService, times(1)).getIntermediaryInfo(anyLong());
+        verify(intermediaryService, times(1)).volunteerGetIntermediaryInfo(anyLong());
     }
+
+    @Test
+    void 모집자_중개_프로필_기본_정보_조회() throws Exception {
+        // given
+        Long intermediaryId = 1L;
+        IntermediaryGetInfoResponse response = new IntermediaryGetInfoResponse("profileImage",
+                "이동봉사 중개 이름", "안녕하세요. 한 줄 소개 입니다.", "https://connectdog.site", "인스타그램: @hoxjeong", "안내 사항입니다.");
+
+        // when
+        given(intermediaryService.intermediaryGetIntermediaryInfo(anyString())).willReturn(response);
+        ResultActions result = mockMvc.perform(
+                get("/intermediaries")
+        );
+
+        // then
+        result.andExpect(status().isOk());
+        verify(intermediaryService, times(1)).intermediaryGetIntermediaryInfo(anyString());
+    }
+
 
     @Test
     void 이동봉사자_중개_프로필_후기_조회() throws Exception {

--- a/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
@@ -100,7 +100,7 @@ class IntermediaryControllerTest {
         //when
         given(intermediaryService.intermediaryGetIntermediaryPosts(anyString(), anyString(), any())).willReturn(response);
         ResultActions result = mockMvc.perform(
-                get("/intermediaries/posts")
+                get("/intermediaries/my/posts")
                         .param("orderCondition", "최신순")
         );
 
@@ -137,7 +137,7 @@ class IntermediaryControllerTest {
         // when
         given(intermediaryService.intermediaryGetIntermediaryInfo(anyString())).willReturn(response);
         ResultActions result = mockMvc.perform(
-                get("/intermediaries")
+                get("/intermediaries/my/info")
         );
 
         // then
@@ -206,7 +206,7 @@ class IntermediaryControllerTest {
         // when
         given(intermediaryService.intermediaryGetIntermediaryReviews(anyString(), any())).willReturn(response);
         ResultActions result = mockMvc.perform(
-                get("/intermediaries/reviews", intermediaryId)
+                get("/intermediaries/my/reviews", intermediaryId)
                         .param("page", "0")
                         .param("size", "2")
         );


### PR DESCRIPTION
## 💡 연관된 이슈
close #190 

## 📝 작업 내용
- 모집자 프로필 - 기본 정보 조회 API 구현
- 모집자 프로필 - 기본 정보 조회 API 테스트 코드 작성

## 💬 리뷰 요구 사항
모집자 프로필 후기 조회 시 이동봉사자 & 모집자를 분리해서 API 구현했던 것처럼, 모집자 프로필 기본 정도 조회도 마찬가지로 분리하여 구현했습니다. (코넥독 1.0에서는 해당 API는 없었기에 추가 개발입니다 :)