### PR TITLE
[Feature] 알림 전송 구현 및 알림 목록 조회를 위한 Entity 생성

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
@@ -6,30 +6,26 @@ import com.pawwithu.connectdog.domain.application.entity.Application;
 import com.pawwithu.connectdog.domain.application.entity.ApplicationStatus;
 import com.pawwithu.connectdog.domain.application.repository.ApplicationRepository;
 import com.pawwithu.connectdog.domain.application.repository.CustomApplicationRepository;
-import com.pawwithu.connectdog.domain.dogStatus.repository.DogStatusRepository;
+import com.pawwithu.connectdog.domain.fcm.entity.VolunteerFcm;
+import com.pawwithu.connectdog.domain.fcm.repository.VolunteerFcmRepository;
+import com.pawwithu.connectdog.domain.fcm.service.FcmService;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
 import com.pawwithu.connectdog.domain.post.entity.Post;
 import com.pawwithu.connectdog.domain.post.entity.PostStatus;
-import com.pawwithu.connectdog.domain.post.repository.CustomPostRepository;
 import com.pawwithu.connectdog.domain.post.repository.PostRepository;
-import com.pawwithu.connectdog.domain.review.repository.ReviewRepository;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import com.pawwithu.connectdog.domain.volunteer.repository.VolunteerRepository;
 import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
-import jakarta.persistence.LockModeType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.hibernate.exception.ConstraintViolationException;
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.Lock;
-import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.pawwithu.connectdog.domain.fcm.dto.NotificationMessage.*;
 import static com.pawwithu.connectdog.error.ErrorCode.*;
 
 @Slf4j
@@ -43,6 +39,8 @@ public class ApplicationService {
     private final ApplicationRepository applicationRepository;
     private final CustomApplicationRepository customApplicationRepository;
     private final IntermediaryRepository intermediaryRepository;
+    private final VolunteerFcmRepository volunteerFcmRepository;
+    private final FcmService fcmService;
 
     public void volunteerApply(String email, Long postId, VolunteerApplyRequest request) {
         // 이동봉사자
@@ -113,6 +111,13 @@ public class ApplicationService {
         // 상태 업데이트 (승인 대기중 -> 진행중)
         application.updateStatus(ApplicationStatus.PROGRESSING);
         post.updateStatus(PostStatus.PROGRESSING);
+        // 알림 전송
+        VolunteerFcm volunteerFcm = volunteerFcmRepository.findByVolunteerId(application.getVolunteer().getId()).orElse(null);
+        if (volunteerFcm != null) {
+            fcmService.sendMessageToVolunteer(volunteerFcm.getFcmToken(), application.getVolunteer(), post.getMainImage().getImage(), CONFIRM.getTitle(), CONFIRM.getBody());
+        } else {
+            log.info("----------이동봉사 승인 알림 전송 실패----------");
+        }
         ApplicationSuccessResponse isSuccess = ApplicationSuccessResponse.of(true);
         return isSuccess;
     }
@@ -126,6 +131,13 @@ public class ApplicationService {
         // 상태 업데이트 (승인 대기중 -> 모집중)
         post.updateStatus(PostStatus.RECRUITING);
         application.updateStatus(ApplicationStatus.REJECTED);
+        // 알림 전송
+        VolunteerFcm volunteerFcm = volunteerFcmRepository.findByVolunteerId(application.getVolunteer().getId()).orElse(null);
+        if (volunteerFcm != null) {
+            fcmService.sendMessageToVolunteer(volunteerFcm.getFcmToken(), application.getVolunteer(), post.getMainImage().getImage(), REJECT.getTitle(), REJECT.getBody());
+        } else {
+            log.info("----------이동봉사 반려 알림 전송 실패----------");
+        }
         ApplicationSuccessResponse isSuccess = ApplicationSuccessResponse.of(true);
         return isSuccess;
     }
@@ -189,6 +201,13 @@ public class ApplicationService {
         // 상태 업데이트 (진행중 -> 봉사 완료)
         application.updateStatus(ApplicationStatus.COMPLETED);
         post.updateStatus(PostStatus.COMPLETED);
+        // 알림 전송
+        VolunteerFcm volunteerFcm = volunteerFcmRepository.findByVolunteerId(application.getVolunteer().getId()).orElse(null);
+        if (volunteerFcm != null) {
+            fcmService.sendMessageToVolunteer(volunteerFcm.getFcmToken(), application.getVolunteer(), post.getMainImage().getImage(), COMPLETED.getTitle(), COMPLETED.getBody());
+        } else {
+            log.info("----------이동봉사 완료 알림 전송 실패----------");
+        }
         ApplicationSuccessResponse isSuccess = ApplicationSuccessResponse.of(true);
         return isSuccess;
     }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/service/ApplicationService.java
@@ -6,7 +6,9 @@ import com.pawwithu.connectdog.domain.application.entity.Application;
 import com.pawwithu.connectdog.domain.application.entity.ApplicationStatus;
 import com.pawwithu.connectdog.domain.application.repository.ApplicationRepository;
 import com.pawwithu.connectdog.domain.application.repository.CustomApplicationRepository;
+import com.pawwithu.connectdog.domain.fcm.entity.IntermediaryFcm;
 import com.pawwithu.connectdog.domain.fcm.entity.VolunteerFcm;
+import com.pawwithu.connectdog.domain.fcm.repository.IntermediaryFcmRepository;
 import com.pawwithu.connectdog.domain.fcm.repository.VolunteerFcmRepository;
 import com.pawwithu.connectdog.domain.fcm.service.FcmService;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
@@ -40,6 +42,7 @@ public class ApplicationService {
     private final CustomApplicationRepository customApplicationRepository;
     private final IntermediaryRepository intermediaryRepository;
     private final VolunteerFcmRepository volunteerFcmRepository;
+    private final IntermediaryFcmRepository intermediaryFcmRepository;
     private final FcmService fcmService;
 
     public void volunteerApply(String email, Long postId, VolunteerApplyRequest request) {
@@ -49,18 +52,22 @@ public class ApplicationService {
         Post post = postRepository.findById(postId).orElseThrow(() -> new BadRequestException(POST_NOT_FOUND));
         // 이동봉사 중개
         Intermediary intermediary = post.getIntermediary();
-
         // 해당 공고에 대한 신청이 이미 존재할 경우 - 신청 상태가 반려가 아닐 경우
         if (customApplicationRepository.existsByPostIdAndPostStatus(postId)) {
             throw new BadRequestException(ALREADY_EXIST_APPLICATION);
         }
-
         // 공고 신청 저장
         Application application = request.toEntity(post, intermediary, volunteer);
         applicationRepository.save(application);
-
         // 공고 상태 승인 대기 중으로 변경
         post.updateStatus(PostStatus.WAITING);
+        // 알림 전송
+        IntermediaryFcm intermediaryFcm = intermediaryFcmRepository.findByIntermediaryId(intermediary.getId()).orElse(null);
+        if (intermediaryFcm != null) {
+            fcmService.sendMessageToIntermediary(intermediaryFcm.getFcmToken(), intermediary, volunteer.getProfileImageNum() + "", APPLICATION.getTitle(), APPLICATION.getBodyWithName(volunteer.getNickname()));
+        } else {
+            log.info("----------이동봉사 신청 알림 전송 실패----------");
+        }
     }
 
     @Transactional(readOnly = true)
@@ -98,6 +105,13 @@ public class ApplicationService {
         // 상태 업데이트 (승인 대기중 -> 모집중)
         Post post = application.getPost();
         post.updateStatus(PostStatus.RECRUITING);
+        // 알림 전송
+        IntermediaryFcm intermediaryFcm = intermediaryFcmRepository.findByIntermediaryId(application.getIntermediary().getId()).orElse(null);
+        if (intermediaryFcm != null) {
+            fcmService.sendMessageToIntermediary(intermediaryFcm.getFcmToken(), application.getIntermediary(), volunteer.getProfileImageNum() + "", CANCELED.getTitle(), CANCELED.getBodyWithName(volunteer.getNickname()));
+        } else {
+            log.info("----------이동봉사 신청 취소 알림 전송 실패----------");
+        }
         ApplicationSuccessResponse isSuccess = ApplicationSuccessResponse.of(true);
         return isSuccess;
     }

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/controller/FcmController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/controller/FcmController.java
@@ -64,7 +64,7 @@ public class FcmController {
             })
     @PostMapping("/fcm-test")
     public ResponseEntity<Void> testFcmToken(@Valid @RequestBody FcmTokenRequest request) {
-        fcmService.sendMessageTo(request.fcmToken(), APPLICATION.getTitleWithLoc("서울 강남구", "서울 도봉구"), APPLICATION.getBodyWithName("포윗유"));
+        fcmService.sendMessageToVolunteer(request.fcmToken(), null, null, APPLICATION.getTitleWithLoc("서울 강남구", "서울 도봉구"), APPLICATION.getBodyWithName("포윗유"));
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/FcmMessage.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/FcmMessage.java
@@ -25,7 +25,6 @@ public class FcmMessage {
     @AllArgsConstructor
     @Getter
     public static class Notification {
-        private String image;
         private String title;
         private String body;
     }

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/FcmMessage.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/FcmMessage.java
@@ -25,6 +25,7 @@ public class FcmMessage {
     @AllArgsConstructor
     @Getter
     public static class Notification {
+        private String image;
         private String title;
         private String body;
     }

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/NotificationMessage.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/dto/NotificationMessage.java
@@ -6,7 +6,18 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum NotificationMessage {
-    APPLICATION("", "님이 이동봉사를 신청하셨어요. 지금 확인해 보세요!");
+    // 봉사
+    GUIDE("이동봉사 시작하기", "이동봉사, 어떻게 하는 건가요?\n코넥독이 이동봉사 가이드를 준비했어요!"),
+    CONFIRM("이동봉사 승인", "이동봉사가 승인되었어요🎉\n모집자의 연락을 기다려 주세요!"),
+    REJECT("이동봉사 반려", "이동봉사가 반려되었어요😥\n다른 이동봉사를 찾아볼까요?"),
+    COMPLETED("이동봉사 완료", "이동봉사 진행이 완료되었어요🐾\n소중한 후기를 들려주세요!"),
+
+    // 모집자
+    APPLICATION("이동봉사 신청", "님이 이동봉사를 신청하셨어요.\n지금 확인해 보세요!"),
+    CANCELED("이동봉사 신청 취소", "님이 이동봉사를 취소하셨어요.\n해당 공고는 모집중 상태로 변경됩니다."),
+    REVIEW_REGISTERED("이동봉사 후기 등록", "봉사 후기가 등록되었습니다.\n지금 확인해 보세요!"),
+    EXPIRED("이동봉사 모집 기간 만료", "모집 기간 만료로 공고가 마감되었습니다.\n아직 봉사자를 구하지 못했다면 기간을 조정해 보세요!"),
+    COMPLETED_REQUEST("이동봉사 진행 완료", "이동봉사 진행이 완료되었나요?\n봉사 완료 버튼을 눌러주세요!");
 
     private final String title;
     private final String body;
@@ -15,8 +26,8 @@ public enum NotificationMessage {
         return departureLoc + "→" + arrivalLoc;
     }
 
-    public String getBodyWithName(String name) {
-        return name + body;
+    public String getBodyWithName(String nickname) {
+        return nickname + body;
     }
 
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/repository/IntermediaryFcmRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/repository/IntermediaryFcmRepository.java
@@ -3,6 +3,9 @@ package com.pawwithu.connectdog.domain.fcm.repository;
 import com.pawwithu.connectdog.domain.fcm.entity.IntermediaryFcm;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface IntermediaryFcmRepository extends JpaRepository<IntermediaryFcm, Long> {
     void deleteByIntermediaryId(Long id);
+    Optional<IntermediaryFcm> findByIntermediaryId(Long id);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/repository/VolunteerFcmRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/repository/VolunteerFcmRepository.java
@@ -3,6 +3,9 @@ package com.pawwithu.connectdog.domain.fcm.repository;
 import com.pawwithu.connectdog.domain.fcm.entity.VolunteerFcm;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface VolunteerFcmRepository extends JpaRepository<VolunteerFcm, Long> {
     void deleteByVolunteerId(Long id);
+    Optional<VolunteerFcm> findByVolunteerId(Long id);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/service/FcmService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/service/FcmService.java
@@ -13,7 +13,9 @@ import com.pawwithu.connectdog.domain.fcm.repository.IntermediaryFcmRepository;
 import com.pawwithu.connectdog.domain.fcm.repository.VolunteerFcmRepository;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
+import com.pawwithu.connectdog.domain.notification.entity.IntermediaryNotification;
 import com.pawwithu.connectdog.domain.notification.entity.VolunteerNotification;
+import com.pawwithu.connectdog.domain.notification.repository.IntermediaryNotificationRepository;
 import com.pawwithu.connectdog.domain.notification.repository.VolunteerNotificationRepository;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import com.pawwithu.connectdog.domain.volunteer.repository.VolunteerRepository;
@@ -49,6 +51,7 @@ public class FcmService {
     private final IntermediaryRepository intermediaryRepository;
     private final IntermediaryFcmRepository intermediaryFcmRepository;
     private final VolunteerNotificationRepository volunteerNotificationRepository;
+    private final IntermediaryNotificationRepository intermediaryNotificationRepository;
 
     @Transactional(readOnly = true)
     public String getAccessToken() throws IOException {
@@ -70,7 +73,7 @@ public class FcmService {
      * @param body : 알림 내용
      * @return
      * */
-    public String makeMessage(String targetToken, String image, String title, String body) throws JsonProcessingException {
+    public String makeMessage(String targetToken, String title, String body) throws JsonProcessingException {
 
         FcmMessage fcmMessage = FcmMessage.builder()
                 .message(
@@ -78,7 +81,6 @@ public class FcmService {
                                 .token(targetToken)
                                 .notification(
                                         FcmMessage.Notification.builder()
-                                                .image(image)
                                                 .title(title)
                                                 .body(body)
                                                 .build())
@@ -98,7 +100,7 @@ public class FcmService {
     public void sendMessageToVolunteer(String targetToken, Volunteer volunteer, String image, String title, String body) {
 
         try {
-            String message = makeMessage(targetToken, image, title, body);
+            String message = makeMessage(targetToken, title, body);
 
             OkHttpClient client = new OkHttpClient();
             RequestBody requestBody = RequestBody.create(message, MediaType.get("application/json; charset=utf-8"));
@@ -131,7 +133,44 @@ public class FcmService {
             log.error("Fcm 푸시 알람을 전송하는 도중에 에러가 발생했습니다. {}", e.getMessage());
             throw new BadRequestException(NOTIFICATION_SEND_ERROR);
         }
-        return;
+    }
+
+    public void sendMessageToIntermediary(String targetToken, Intermediary intermediary, String image, String title, String body) {
+
+        try {
+            String message = makeMessage(targetToken, title, body);
+
+            OkHttpClient client = new OkHttpClient();
+            RequestBody requestBody = RequestBody.create(message, MediaType.get("application/json; charset=utf-8"));
+
+            Request request = new Request.Builder()
+                    .url(FIREBASE_API_URL)
+                    .post(requestBody)
+                    .addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken())
+                    .addHeader(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8")
+                    .build();
+
+            Response response = client.newCall(request).execute();
+
+            // 알림 저장
+            intermediaryNotificationRepository.save(
+                    IntermediaryNotification.builder()
+                            .image(image)
+                            .title(title)
+                            .body(body)
+                            .intermediary(intermediary)
+                            .isRead(false)
+                            .build()
+            );
+
+            if (!response.isSuccessful()) {
+                log.error("FCM 푸시 알람 전송이 실패했습니다. 응답 코드: {}\n{}", response.code(), response.body().string());
+            }
+        }
+        catch (Exception e) {
+            log.error("Fcm 푸시 알람을 전송하는 도중에 에러가 발생했습니다. {}", e.getMessage());
+            throw new BadRequestException(NOTIFICATION_SEND_ERROR);
+        }
     }
 
     public void saveVolunteerFcm(String email, VolunteerFcmRequest request) {

--- a/src/main/java/com/pawwithu/connectdog/domain/fcm/service/FcmService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/fcm/service/FcmService.java
@@ -13,6 +13,8 @@ import com.pawwithu.connectdog.domain.fcm.repository.IntermediaryFcmRepository;
 import com.pawwithu.connectdog.domain.fcm.repository.VolunteerFcmRepository;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
+import com.pawwithu.connectdog.domain.notification.entity.VolunteerNotification;
+import com.pawwithu.connectdog.domain.notification.repository.VolunteerNotificationRepository;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import com.pawwithu.connectdog.domain.volunteer.repository.VolunteerRepository;
 import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
@@ -32,6 +34,7 @@ import static com.pawwithu.connectdog.error.ErrorCode.*;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class FcmService {
 
     @Value("${fcm.config.path}")
@@ -45,8 +48,10 @@ public class FcmService {
     private final VolunteerFcmRepository volunteerFcmRepository;
     private final IntermediaryRepository intermediaryRepository;
     private final IntermediaryFcmRepository intermediaryFcmRepository;
+    private final VolunteerNotificationRepository volunteerNotificationRepository;
 
-    private String getAccessToken() throws IOException {
+    @Transactional(readOnly = true)
+    public String getAccessToken() throws IOException {
 
         // firebase로 부터 access token을 가져온다.
         GoogleCredentials googleCredentials = GoogleCredentials
@@ -65,7 +70,7 @@ public class FcmService {
      * @param body : 알림 내용
      * @return
      * */
-    public String makeMessage(String targetToken, String title, String body) throws JsonProcessingException {
+    public String makeMessage(String targetToken, String image, String title, String body) throws JsonProcessingException {
 
         FcmMessage fcmMessage = FcmMessage.builder()
                 .message(
@@ -73,6 +78,7 @@ public class FcmService {
                                 .token(targetToken)
                                 .notification(
                                         FcmMessage.Notification.builder()
+                                                .image(image)
                                                 .title(title)
                                                 .body(body)
                                                 .build())
@@ -89,10 +95,10 @@ public class FcmService {
      * 알림 푸쉬를 보내는 역할을 하는 메서드
      * @param targetToken : 푸쉬 알림을 받을 클라이언트 앱의 식별 토큰
      * */
-    public void sendMessageTo(String targetToken, String title, String body) {
+    public void sendMessageToVolunteer(String targetToken, Volunteer volunteer, String image, String title, String body) {
 
         try {
-            String message = makeMessage(targetToken, title, body);
+            String message = makeMessage(targetToken, image, title, body);
 
             OkHttpClient client = new OkHttpClient();
             RequestBody requestBody = RequestBody.create(message, MediaType.get("application/json; charset=utf-8"));
@@ -105,6 +111,18 @@ public class FcmService {
                     .build();
 
             Response response = client.newCall(request).execute();
+
+            // 알림 저장
+            volunteerNotificationRepository.save(
+                    VolunteerNotification.builder()
+                            .image(image)
+                            .title(title)
+                            .body(body)
+                            .volunteer(volunteer)
+                            .isRead(false)
+                            .build()
+            );
+
             if (!response.isSuccessful()) {
                 log.error("FCM 푸시 알람 전송이 실패했습니다. 응답 코드: {}\n{}", response.code(), response.body().string());
             }
@@ -116,14 +134,12 @@ public class FcmService {
         return;
     }
 
-    @Transactional
     public void saveVolunteerFcm(String email, VolunteerFcmRequest request) {
         Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
         VolunteerFcm volunteerFcm = VolunteerFcmRequest.volunteerToEntity(volunteer, request);
         volunteerFcmRepository.save(volunteerFcm);
     }
 
-    @Transactional
     public void saveIntermediaryFcm(String email, IntermediaryFcmRequest request) {
         Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
         IntermediaryFcm intermediaryFcm = IntermediaryFcmRequest.IntermediaryToEntity(intermediary, request);

--- a/src/main/java/com/pawwithu/connectdog/domain/notification/entity/IntermediaryNotification.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/notification/entity/IntermediaryNotification.java
@@ -1,0 +1,36 @@
+package com.pawwithu.connectdog.domain.notification.entity;
+
+import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
+import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class IntermediaryNotification extends BaseTimeEntity {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
+        private String image;
+        @Column(nullable = false)
+        private String title;
+        @Column(nullable = false)
+        private String body;
+        @ManyToOne(fetch = FetchType.LAZY)
+        @JoinColumn(name = "intermediary_id", nullable = false)
+        private Intermediary intermediary;  // 이동봉사 중개 id
+        @Column(nullable = false)
+        private Boolean isRead;
+
+        @Builder
+        public IntermediaryNotification(String image, String title, String body, Intermediary intermediary, Boolean isRead) {
+            this.image = image;
+            this.title = title;
+            this.body = body;
+            this.intermediary = intermediary;
+            this.isRead = isRead;
+        }
+    }

--- a/src/main/java/com/pawwithu/connectdog/domain/notification/entity/VolunteerNotification.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/notification/entity/VolunteerNotification.java
@@ -1,0 +1,36 @@
+package com.pawwithu.connectdog.domain.notification.entity;
+
+import com.pawwithu.connectdog.common.entity.BaseTimeEntity;
+import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class VolunteerNotification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    private String image;
+    @Column(nullable = false)
+    private String title;
+    @Column(nullable = false)
+    private String body;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "volunteer_id", nullable = false)
+    private Volunteer volunteer;  // 이동봉사자 id
+    @Column(nullable = false)
+    private Boolean isRead;
+
+    @Builder
+    public VolunteerNotification(String image, String title, String body, Volunteer volunteer, Boolean isRead) {
+        this.image = image;
+        this.title = title;
+        this.body = body;
+        this.volunteer = volunteer;
+        this.isRead = isRead;
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/notification/repository/IntermediaryNotificationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/notification/repository/IntermediaryNotificationRepository.java
@@ -1,0 +1,7 @@
+package com.pawwithu.connectdog.domain.notification.repository;
+
+import com.pawwithu.connectdog.domain.notification.entity.IntermediaryNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface IntermediaryNotificationRepository extends JpaRepository<IntermediaryNotification, Long> {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/notification/repository/VolunteerNotificationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/notification/repository/VolunteerNotificationRepository.java
@@ -1,0 +1,7 @@
+package com.pawwithu.connectdog.domain.notification.repository;
+
+import com.pawwithu.connectdog.domain.notification.entity.VolunteerNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VolunteerNotificationRepository extends JpaRepository<VolunteerNotification, Long> {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/review/service/ReviewService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/review/service/ReviewService.java
@@ -2,6 +2,9 @@ package com.pawwithu.connectdog.domain.review.service;
 
 import com.pawwithu.connectdog.common.s3.FileService;
 import com.pawwithu.connectdog.domain.application.repository.ApplicationRepository;
+import com.pawwithu.connectdog.domain.fcm.entity.IntermediaryFcm;
+import com.pawwithu.connectdog.domain.fcm.repository.IntermediaryFcmRepository;
+import com.pawwithu.connectdog.domain.fcm.service.FcmService;
 import com.pawwithu.connectdog.domain.post.entity.Post;
 import com.pawwithu.connectdog.domain.post.repository.PostRepository;
 import com.pawwithu.connectdog.domain.review.dto.request.ReviewCreateRequest;
@@ -26,6 +29,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static com.pawwithu.connectdog.domain.fcm.dto.NotificationMessage.REVIEW_REGISTERED;
 import static com.pawwithu.connectdog.error.ErrorCode.*;
 
 @Slf4j
@@ -41,6 +45,8 @@ public class ReviewService {
     private final ReviewImageRepository reviewImageRepository;
     private final CustomReviewRepository customReviewRepository;
     private final ApplicationRepository applicationRepository;
+    private final IntermediaryFcmRepository intermediaryFcmRepository;
+    private final FcmService fcmService;
 
     public void createReview(String email, Long postId, ReviewCreateRequest request, List<MultipartFile> fileList) {
 
@@ -71,6 +77,14 @@ public class ReviewService {
 
         // 후기 대표 이미지 업데이트
         review.updateMainImage(reviewImages.get(0));
+
+        // 알림 전송
+        IntermediaryFcm intermediaryFcm = intermediaryFcmRepository.findByIntermediaryId(post.getIntermediary().getId()).orElse(null);
+        if (intermediaryFcm != null) {
+            fcmService.sendMessageToIntermediary(intermediaryFcm.getFcmToken(), post.getIntermediary(), post.getMainImage().getImage(), REVIEW_REGISTERED.getTitle(), REVIEW_REGISTERED.getBody());
+        } else {
+            log.info("----------이동봉사 후기 등록 알림 전송 실패----------");
+        }
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## 💡 연관된 이슈
close #189 

## 📝 작업 내용
- 이동봉사자, 모집자의 알림을 저장하는 Entity 생성
- 봉사자 알림 전송 및 저장 구현 (이동봉사 승인, 반려, 완료)
- 모집자 알림 전송 및 저장 구현 (이동봉사 신청, 신청 취소, 후기 등록)

## 💬 리뷰 요구 사항
Notification Entity
- 봉사자와 모집자의 Notification Entity를 구분했고, 알림을 봉사자는 VolunteerNotification에 모집자는 IntermediaryNotification에 저장하여 알림 목록 조회 시 봉사자id, 모집자id로 불러올 수 있도록 구현했습니다! (하나의 Entity에 구현할 수도 있었지만 분리하는 것이 관리와 조회면에서 이점이 있다고 생각했습니다.)
- Notification 필드에 isRead를 두어 해당 알림의 읽음 여부를 판단할 수 있도록 했습니다.

NotificationMessage (알림 제목, 내용)
- NotificationMessage를 통해서 알림 메시지에 대해 유지보수가 용이하게 개발했습니다! 이동봉사자의 닉네임에 따라 변경되는 메시지의 내용을 메서드로 통일성 있게 구현했습니다

알림 전송 및 저장
- 알림을 전송하는 메서드 내에 알림을 저장하는 로직을 추가하여 알림을 전송하고 해당 알림을 목록에 저장할 수 있도록 구현하였습니다. 이는 봉사자와 모집자의 Notification Entity를 분리했기 때문에 메서드를 분리하여 사용했습니다.

<br>
이전에 Fcm Token을 이용해 알림이 전송되는지 테스트는 진행했지만, 이번 작업에서 트리거 발생 시 Fcm Token을 통한 테스트를 따로 진행하지 않아 프론트와 확인해 보면 좋을 것 같습니다.