### PR TITLE
[Feature] 비밀번호 변경 - 봉사자/모집자 기존 비밀번호 확인 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryController.java
@@ -1,9 +1,12 @@
 package com.pawwithu.connectdog.domain.intermediary.controller;
 
 import com.pawwithu.connectdog.domain.intermediary.dto.request.IntermediaryMyProfileRequest;
+import com.pawwithu.connectdog.domain.intermediary.dto.request.IntermediaryPasswordCheckRequest;
 import com.pawwithu.connectdog.domain.intermediary.dto.request.IntermediaryPasswordRequest;
 import com.pawwithu.connectdog.domain.intermediary.dto.response.*;
 import com.pawwithu.connectdog.domain.intermediary.service.IntermediaryService;
+import com.pawwithu.connectdog.domain.volunteer.dto.request.VolunteerPasswordCheckRequest;
+import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerPasswordCheckResponse;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -163,6 +166,18 @@ public class IntermediaryController {
     public ResponseEntity<Void> changePassword(@AuthenticationPrincipal UserDetails loginUser, @RequestBody IntermediaryPasswordRequest request) {
         intermediaryService.changePassword(loginUser.getUsername(), request.password());
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "비밀번호 변경 - 모집자 기존 비밀번호 확인", description = "모집자 기존 비밀번호를 확인합니다.",
+            responses = {@ApiResponse(responseCode = "204", description = "기존 비밀번호 확인 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M2, 해당 이동봉사 중개를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = Boolean.class)))
+            })
+    @PostMapping("/intermediaries/password/check")
+    public ResponseEntity<IntermediaryPasswordCheckResponse> checkPassword(@AuthenticationPrincipal UserDetails loginUser, @RequestBody IntermediaryPasswordCheckRequest request) {
+        IntermediaryPasswordCheckResponse response = intermediaryService.checkPassword(loginUser.getUsername(), request.password());
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "설정 - 모집자 알림 설정", description = "모집자 알림을 설정합니다.",

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/request/IntermediaryPasswordCheckRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/request/IntermediaryPasswordCheckRequest.java
@@ -1,0 +1,4 @@
+package com.pawwithu.connectdog.domain.intermediary.dto.request;
+
+public record IntermediaryPasswordCheckRequest(String password) {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/response/IntermediaryPasswordCheckResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/dto/response/IntermediaryPasswordCheckResponse.java
@@ -1,0 +1,8 @@
+package com.pawwithu.connectdog.domain.intermediary.dto.response;
+
+public record IntermediaryPasswordCheckResponse(Boolean isChecked) {
+
+    public static IntermediaryPasswordCheckResponse of(Boolean isChecked) {
+        return new IntermediaryPasswordCheckResponse(isChecked);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/intermediary/service/IntermediaryService.java
@@ -9,6 +9,8 @@ import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryReposi
 import com.pawwithu.connectdog.domain.post.entity.PostStatus;
 import com.pawwithu.connectdog.domain.post.repository.CustomPostRepository;
 import com.pawwithu.connectdog.domain.review.repository.CustomReviewRepository;
+import com.pawwithu.connectdog.domain.volunteer.dto.response.VolunteerPasswordCheckResponse;
+import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import com.pawwithu.connectdog.error.exception.custom.BadRequestException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 
 import static com.pawwithu.connectdog.error.ErrorCode.INTERMEDIARY_NOT_FOUND;
+import static com.pawwithu.connectdog.error.ErrorCode.VOLUNTEER_NOT_FOUND;
 
 @Slf4j
 @Service
@@ -155,6 +158,13 @@ public class IntermediaryService {
         intermediary.passwordEncode(passwordEncoder);
     }
 
+    public IntermediaryPasswordCheckResponse checkPassword(String email, String password) {
+        Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
+        boolean isChecked =  passwordEncoder.matches(password, intermediary.getPassword());
+        return IntermediaryPasswordCheckResponse.of(isChecked);
+    }
+
+
     public void changeNotification(String email) {
         Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
         intermediary.updateNotification();
@@ -166,4 +176,5 @@ public class IntermediaryService {
         IntermediaryGetNotificationResponse response = IntermediaryGetNotificationResponse.of(intermediary.getNotification());
         return response;
     }
+
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerController.java
@@ -126,7 +126,7 @@ public class VolunteerController {
     @Operation(summary = "비밀번호 변경 - 이동봉사자 기존 비밀번호 확인", description = "이동봉사자 기존 비밀번호를 확인합니다.",
             responses = {@ApiResponse(responseCode = "204", description = "기존 비밀번호 확인 성공")
                     , @ApiResponse(responseCode = "400"
-                    , description = "M1, 해당 이동봉사자를 찾을 수 없습니다. \t\n V1, 영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상을 입력해 주세요."
+                    , description = "M1, 해당 이동봉사자를 찾을 수 없습니다."
                     , content = @Content(schema = @Schema(implementation = Boolean.class)))
             })
     @PostMapping("/password/check")

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerController.java
@@ -1,9 +1,6 @@
 package com.pawwithu.connectdog.domain.volunteer.controller;
 
-import com.pawwithu.connectdog.domain.volunteer.dto.request.AdditionalAuthRequest;
-import com.pawwithu.connectdog.domain.volunteer.dto.request.NicknameRequest;
-import com.pawwithu.connectdog.domain.volunteer.dto.request.VolunteerMyProfileRequest;
-import com.pawwithu.connectdog.domain.volunteer.dto.request.VolunteerPasswordRequest;
+import com.pawwithu.connectdog.domain.volunteer.dto.request.*;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.*;
 import com.pawwithu.connectdog.domain.volunteer.service.VolunteerService;
 import com.pawwithu.connectdog.error.dto.ErrorResponse;
@@ -41,7 +38,7 @@ public class VolunteerController {
     }
 
     @Operation(summary = "이름, 전화번호 추가 인증", description = "이름과 전화번호를 추가로 인증합니다.",
-            security = { @SecurityRequirement(name = "bearer-key") },
+            security = {@SecurityRequirement(name = "bearer-key")},
             responses = {
                     @ApiResponse(responseCode = "204", description = "이름, 전화번호 추가 인증 성공")
                     , @ApiResponse(responseCode = "400", description = "V1, 이름은 필수 입력 값입니다. \t\n V1, 휴대전화 번호는 필수 입력 값입니다. \t\n V1, 유효하지 않은 휴대전화 번호입니다.",
@@ -90,7 +87,7 @@ public class VolunteerController {
     }
 
     @Operation(summary = "마이페이지 프로필 수정", description = "마이페이지 프로필을 수정합니다.",
-            security = { @SecurityRequirement(name = "bearer-key") },
+            security = {@SecurityRequirement(name = "bearer-key")},
             responses = {@ApiResponse(responseCode = "204", description = "마이페이지 프로필 수정 성공")
                     , @ApiResponse(responseCode = "400"
                     , description = "V1, 닉네임은 한글, 숫자만 사용 가능합니다. \t\n V1, 닉네임은 필수 입력 값입니다. \t\n V1, 닉네임은 2~10자로 입력해 주세요. \t\n A2, 이미 사용 중인 닉네임입니다. \t\n M1, 해당 이동봉사자를 찾을 수 없습니다."
@@ -124,6 +121,18 @@ public class VolunteerController {
     public ResponseEntity<Void> changePassword(@AuthenticationPrincipal UserDetails loginUser, @RequestBody VolunteerPasswordRequest request) {
         volunteerService.changePassword(loginUser.getUsername(), request.password());
         return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "비밀번호 변경 - 이동봉사자 기존 비밀번호 확인", description = "이동봉사자 기존 비밀번호를 확인합니다.",
+            responses = {@ApiResponse(responseCode = "204", description = "기존 비밀번호 확인 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "M1, 해당 이동봉사자를 찾을 수 없습니다. \t\n V1, 영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상을 입력해 주세요."
+                    , content = @Content(schema = @Schema(implementation = Boolean.class)))
+            })
+    @PostMapping("/password/check")
+    public ResponseEntity<VolunteerPasswordCheckResponse> checkPassword(@AuthenticationPrincipal UserDetails loginUser, @RequestBody VolunteerPasswordCheckRequest request) {
+        VolunteerPasswordCheckResponse response = volunteerService.checkPassword(loginUser.getUsername(), request.password());
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "설정 - 이동봉사자 알림 설정", description = "이동봉사자 알림을 설정합니다.",

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/request/VolunteerPasswordCheckRequest.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/request/VolunteerPasswordCheckRequest.java
@@ -1,0 +1,4 @@
+package com.pawwithu.connectdog.domain.volunteer.dto.request;
+
+public record VolunteerPasswordCheckRequest(String password) {
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/response/VolunteerPasswordCheckResponse.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/dto/response/VolunteerPasswordCheckResponse.java
@@ -1,0 +1,8 @@
+package com.pawwithu.connectdog.domain.volunteer.dto.response;
+
+public record VolunteerPasswordCheckResponse(Boolean isChecked) {
+
+    public static VolunteerPasswordCheckResponse of(Boolean isChecked) {
+        return new VolunteerPasswordCheckResponse(isChecked);
+    }
+}

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/service/VolunteerService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/service/VolunteerService.java
@@ -125,6 +125,12 @@ public class VolunteerService {
         volunteer.passwordEncode(passwordEncoder);
     }
 
+    public VolunteerPasswordCheckResponse checkPassword(String email, String password) {
+        Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
+        boolean isChecked =  passwordEncoder.matches(password, volunteer.getPassword());
+        return VolunteerPasswordCheckResponse.of(isChecked);
+    }
+
     public void changeNotification(String email) {
         Volunteer volunteer = volunteerRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
         volunteer.updateNotification();
@@ -136,4 +142,5 @@ public class VolunteerService {
         VolunteerGetNotificationResponse response = VolunteerGetNotificationResponse.of(volunteer.getNotification());
         return response;
     }
+
 }

--- a/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/intermediary/controller/IntermediaryControllerTest.java
@@ -4,9 +4,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.pawwithu.connectdog.domain.dog.entity.DogSize;
 import com.pawwithu.connectdog.domain.intermediary.dto.request.IntermediaryMyProfileRequest;
+import com.pawwithu.connectdog.domain.intermediary.dto.request.IntermediaryPasswordCheckRequest;
 import com.pawwithu.connectdog.domain.intermediary.dto.request.IntermediaryPasswordRequest;
 import com.pawwithu.connectdog.domain.intermediary.dto.response.*;
 import com.pawwithu.connectdog.domain.intermediary.service.IntermediaryService;
+import com.pawwithu.connectdog.domain.volunteer.dto.request.VolunteerPasswordCheckRequest;
 import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,8 +38,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @ExtendWith(MockitoExtension.class)
@@ -300,7 +301,23 @@ class IntermediaryControllerTest {
         // then
         result.andExpect(status().isNoContent());
         verify(intermediaryService, times(1)).changePassword(anyString(), any());
+    }
 
+    @Test
+    void 모집자_기존_비밀번호_확인() throws Exception {
+        // given
+        IntermediaryPasswordCheckRequest request = new IntermediaryPasswordCheckRequest("oldPassword");
+
+        // when
+        ResultActions result = mockMvc.perform(
+                post("/intermediaries/password/check")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        result.andExpect(status().isOk());
+        verify(intermediaryService, times(1)).checkPassword(anyString(), anyString());
     }
 
     @Test

--- a/src/test/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/volunteer/controller/VolunteerControllerTest.java
@@ -4,10 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pawwithu.connectdog.domain.dog.entity.DogSize;
 import com.pawwithu.connectdog.domain.post.dto.response.PostGetHomeResponse;
-import com.pawwithu.connectdog.domain.volunteer.dto.request.AdditionalAuthRequest;
-import com.pawwithu.connectdog.domain.volunteer.dto.request.NicknameRequest;
-import com.pawwithu.connectdog.domain.volunteer.dto.request.VolunteerMyProfileRequest;
-import com.pawwithu.connectdog.domain.volunteer.dto.request.VolunteerPasswordRequest;
+import com.pawwithu.connectdog.domain.volunteer.dto.request.*;
 import com.pawwithu.connectdog.domain.volunteer.dto.response.*;
 import com.pawwithu.connectdog.domain.volunteer.service.VolunteerService;
 import com.pawwithu.connectdog.utils.TestUserArgumentResolver;
@@ -196,6 +193,24 @@ class VolunteerControllerTest {
         result.andExpect(status().isNoContent());
         verify(volunteerService, times(1)).changePassword(anyString(), any());
     }
+
+    @Test
+    void 이동봉사자_기존_비밀번호_확인() throws Exception {
+        // given
+        VolunteerPasswordCheckRequest request = new VolunteerPasswordCheckRequest("oldPassword");
+
+        // when
+        ResultActions result = mockMvc.perform(
+                post("/volunteers/password/check")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+
+        // then
+        result.andExpect(status().isOk());
+        verify(volunteerService, times(1)).checkPassword(anyString(), anyString());
+    }
+
 
     @Test
     void 이동봉사자_알림_설정() throws Exception {


### PR DESCRIPTION
## 💡 연관된 이슈
close #216 

## 📝 작업 내용
- 비밀번호 변경 - 봉사자/모집자 기존 비밀번호 확인 API
- 비밀번호 변경 - 봉사자/모집자 기존 비밀번호 확인 테스트 코드

## 💬 리뷰 요구 사항
마이페이지에서 비밀번호 변경 시 기존 비밀번호 확인 -> 새 비밀번호 설정 단계인데요,
이 API로 기존 비밀번호와 일치하는지 여부를 판단하고
새 비밀번호 설정은 기존의 비밀번호 변경 API를 이용하면 될 것 같습니다!