### PR TITLE
[Feature] 모집자 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/application/entity/Application.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/entity/Application.java
@@ -56,4 +56,8 @@ public class Application extends BaseTimeEntity {
         this.volunteerName = deletedVolunteer.getName();
         this.phone = deletedVolunteer.getPhone();
     }
+
+    public void updateDeletedIntermediary(Intermediary deletedIntermediary) {
+        this.intermediary = deletedIntermediary;
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/application/repository/ApplicationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/application/repository/ApplicationRepository.java
@@ -2,6 +2,7 @@ package com.pawwithu.connectdog.domain.application.repository;
 
 import com.pawwithu.connectdog.domain.application.entity.Application;
 import com.pawwithu.connectdog.domain.application.entity.ApplicationStatus;
+import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.volunteer.entity.Volunteer;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -17,5 +18,7 @@ public interface ApplicationRepository extends JpaRepository<Application, Long> 
     Long countAllByPostId(Long id);
     List<Application> findByVolunteer(Volunteer volunteer);
     Optional<Application> findByPostIdAndStatusNot(Long postId, ApplicationStatus status);
+
+    List<Application> findByIntermediary(Intermediary intermediary);
 
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/AuthController.java
@@ -83,4 +83,17 @@ public class AuthController {
         return ResponseEntity.noContent().build();
     }
 
+    @Operation(summary = "모집자 - 탈퇴", description = "모집자가 탈퇴를 합니다.",
+            security = {@SecurityRequirement(name = "bearer-key") },
+            responses = {@ApiResponse(responseCode = "200", description = "모집자 탈퇴 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "T1, 토큰이 존재하지 않습니다. \t\n M2, 해당 이동봉사 중개를 찾을 수 없습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @DeleteMapping("/intermediaries/my")
+    public ResponseEntity<Void> intermediariesWithdraw(HttpServletRequest request, @AuthenticationPrincipal UserDetails loginUser) {
+        authService.intermediariesWithdraw(request, loginUser.getUsername());
+        return ResponseEntity.noContent().build();
+    }
+
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
@@ -9,10 +9,16 @@ import com.pawwithu.connectdog.domain.auth.dto.response.IntermediaryPhoneRespons
 import com.pawwithu.connectdog.domain.auth.dto.response.VolunteerPhoneResponse;
 import com.pawwithu.connectdog.domain.badge.repository.VolunteerBadgeRepository;
 import com.pawwithu.connectdog.domain.bookmark.repository.BookmarkRepository;
+import com.pawwithu.connectdog.domain.dogStatus.repository.DogStatusImageRepository;
+import com.pawwithu.connectdog.domain.dogStatus.repository.DogStatusRepository;
 import com.pawwithu.connectdog.domain.fcm.repository.IntermediaryFcmRepository;
 import com.pawwithu.connectdog.domain.fcm.repository.VolunteerFcmRepository;
 import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.intermediary.repository.IntermediaryRepository;
+import com.pawwithu.connectdog.domain.notification.repository.IntermediaryNotificationRepository;
+import com.pawwithu.connectdog.domain.notification.repository.VolunteerNotificationRepository;
+import com.pawwithu.connectdog.domain.post.entity.Post;
+import com.pawwithu.connectdog.domain.post.repository.PostRepository;
 import com.pawwithu.connectdog.domain.review.entity.Review;
 import com.pawwithu.connectdog.domain.review.repository.ReviewRepository;
 import com.pawwithu.connectdog.domain.volunteer.entity.SocialType;
@@ -54,6 +60,11 @@ public class AuthService {
     private final IntermediaryFcmRepository intermediaryFcmRepository;
     private final BookmarkRepository bookmarkRepository;
     private final VolunteerBadgeRepository volunteerBadgeRepository;
+    private final PostRepository postRepository;
+    private final IntermediaryNotificationRepository intermediaryNotificationRepository;
+    private final VolunteerNotificationRepository volunteerNotificationRepository;
+    private final DogStatusRepository dogStatusRepository;
+    private final DogStatusImageRepository dogStatusImageRepository;
 
     public void volunteerSignUp(VolunteerSignUpRequest request) {
 
@@ -175,7 +186,7 @@ public class AuthService {
             volunteerFcmRepository.deleteByVolunteerId(volunteer.getId());
             redisUtil.setBlackList(accessToken, "accessToken", jwtService.getAccessTokenExpirationPeriod());
 
-            Volunteer deletedVolunteer = volunteerRepository.findByEmail("deleted@connectdog.com").orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
+            Volunteer deletedVolunteer = volunteerRepository.findByEmail("deletedVolunteer@connectdog.com").orElseThrow(() -> new BadRequestException(VOLUNTEER_NOT_FOUND));
             List<Review> reviews = reviewRepository.findByVolunteer(volunteer);
             for (Review review : reviews) {
                 review.updateDeletedVolunteer(deletedVolunteer);
@@ -190,10 +201,45 @@ public class AuthService {
 
             bookmarkRepository.deleteByVolunteerId(volunteer.getId());
             volunteerBadgeRepository.deleteByVolunteerId(volunteer.getId());
+            volunteerNotificationRepository.deleteByVolunteerId(volunteer.getId());
+            volunteerFcmRepository.deleteByVolunteerId(volunteer.getId());
             volunteerRepository.delete(volunteer);
         } catch (Exception e) {
             log.error("봉사자 탈퇴 도중에 에러가 발생했습니다. {}", e.getMessage());
             throw new BadRequestException(VOLUNTEER_WITHDRAW_FAILED);
+        }
+    }
+
+    public void intermediariesWithdraw(HttpServletRequest request, String email) {
+        String accessToken = jwtService.extractAccessToken(request).orElseThrow(() -> new BadRequestException(TOKEN_NOT_EXIST));
+        Intermediary intermediary = intermediaryRepository.findByEmail(email).orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
+        String roleName = jwtService.extractRoleName(accessToken).orElseThrow(() -> new BadRequestException(NOT_FOUND_ROLE_NAME));
+
+        try {
+            redisUtil.delete(roleName, intermediary.getId());
+            volunteerFcmRepository.deleteByVolunteerId(intermediary.getId());
+            redisUtil.setBlackList(accessToken, "accessToken", jwtService.getAccessTokenExpirationPeriod());
+
+            Intermediary deletedIntermediary = intermediaryRepository.findByEmail("deletedIntermediary@connectdog.com").orElseThrow(() -> new BadRequestException(INTERMEDIARY_NOT_FOUND));
+
+            List<Post> posts = postRepository.findByIntermediary(intermediary);
+            for (Post post : posts) {
+                post.updateDeletedIntermediary(deletedIntermediary);
+            }
+
+            List<Application> applications = applicationRepository.findByIntermediary(intermediary);
+            for (Application application : applications) {
+                application.updateDeletedIntermediary(deletedIntermediary);
+            }
+
+            entityManager.flush();
+
+            intermediaryNotificationRepository.deleteByIntermediaryId(intermediary.getId());
+            intermediaryFcmRepository.deleteByIntermediaryId(intermediary.getId());
+            intermediaryRepository.delete(intermediary);
+        } catch (Exception e) {
+            log.error("모집자 탈퇴 도중에 에러가 발생했습니다. {}", e.getMessage());
+            throw new BadRequestException(INTERMEDIARY_WITHDRAW_FAILED);
         }
     }
 

--- a/src/main/java/com/pawwithu/connectdog/domain/notification/repository/IntermediaryNotificationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/notification/repository/IntermediaryNotificationRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface IntermediaryNotificationRepository extends JpaRepository<IntermediaryNotification, Long> {
 
     Optional<IntermediaryNotification> findByIdAndIntermediaryId(Long id, Long intermediaryId);
+
+    void deleteByIntermediaryId(Long id);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/notification/repository/VolunteerNotificationRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/notification/repository/VolunteerNotificationRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface VolunteerNotificationRepository extends JpaRepository<VolunteerNotification, Long> {
 
     Optional<VolunteerNotification> findByIdAndVolunteerId(Long id, Long intermediaryId);
+
+    void deleteByVolunteerId(Long id);
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/entity/Post.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/entity/Post.java
@@ -74,4 +74,8 @@ public class Post extends BaseTimeEntity {
         this.isKennel = isKennel;
         this.content = content;
     }
+
+    public void updateDeletedIntermediary(Intermediary deletedIntermediary) {
+        this.intermediary = deletedIntermediary;
+    }
 }

--- a/src/main/java/com/pawwithu/connectdog/domain/post/repository/PostRepository.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/post/repository/PostRepository.java
@@ -1,13 +1,17 @@
 package com.pawwithu.connectdog.domain.post.repository;
 
+import com.pawwithu.connectdog.domain.intermediary.entity.Intermediary;
 import com.pawwithu.connectdog.domain.post.entity.Post;
 import com.pawwithu.connectdog.domain.post.entity.PostStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
 
     Optional<Post> findByIdAndIntermediaryId(Long id, Long intermediaryId);
     Optional<Post> findByIdAndStatus(Long id, PostStatus postStatus);
+
+    List<Post> findByIntermediary(Intermediary intermediary);
 }

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -111,7 +111,7 @@ UPDATE post SET main_image_id = 15 WHERE id = 15;
 UPDATE post SET main_image_id = 16 WHERE id = 16;
 
 -- INSERT VOLUNTEER
-INSERT INTO volunteer (id, email, password, nickname, profile_image_num, name, phone, role, is_option_agr, notification, created_date, modified_date) VALUES (7, 'deleted@connectdog.com', '{bcrypt}$2a$10$wkmYUG/qvZFThCzq19yHredRc6u8nAhlAopbDE9p7n6JF6NgtLs8y', '탈퇴한 사용자', 1, '탈퇴한 사용자', '01000000000', 'AUTH_VOLUNTEER', false, true, now(), now());
+INSERT INTO volunteer (id, email, password, nickname, profile_image_num, name, phone, role, is_option_agr, notification, created_date, modified_date) VALUES (7, 'deletedVolunteer@connectdog.com', '{bcrypt}$2a$10$wkmYUG/qvZFThCzq19yHredRc6u8nAhlAopbDE9p7n6JF6NgtLs8y', '탈퇴한 사용자', 1, '탈퇴한 사용자', '01000000000', 'AUTH_VOLUNTEER', false, true, now(), now());
 
 INSERT INTO volunteer (id, email, password, nickname, profile_image_num, name, phone, role, is_option_agr, notification, created_date, modified_date) VALUES (1, 'abc@naver.com', '{bcrypt}$2a$10$VieltvcRaI/rJnaRHuRPju9rqM9BvmKRkmn./oOninx7fOGT/q2De', '이동봉사자', 2, '한호정', '01047391901', 'AUTH_VOLUNTEER', false, true, now(), now());
 
@@ -170,19 +170,19 @@ UPDATE review SET main_image_id = 5 WHERE id = 5;
 
 
 -- INSERT DOG_STATUS
-INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (1, '우리 여름이 집 가서 활짝 웃고있는 거 보세요! 귀여운 여름이와 함께 이동봉사 진행해 주셔서 감사합니다 ^^', 12, 2, now(), now());
-INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (2, '겨울이의 점점 살과 털이 찌고있어요 ㅎㅎ 겨울이는 잘 먹고 잘 지낸답니다. ', 13, 2, now(), now());
-INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (3, '짱구는 모래 운동장에서 노는 걸 요즘 즐겨서 흰 털이 노래질 때까지 놀고있대요^^~', 14, 2, now(), now());
-INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (4, '로지는 이제 사람들 손을 무서워하지 않고 사람들과 함께 잘 노는 강아지가 되어가고 있답니다', 15, 2, now(), now());
-INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (5, '가을이는 다 나아서 잘 지내고 있답니다 :)', 16, 3, now(), now());
+--INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (1, '우리 여름이 집 가서 활짝 웃고있는 거 보세요! 귀여운 여름이와 함께 이동봉사 진행해 주셔서 감사합니다 ^^', 12, 2, now(), now());
+--INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (2, '겨울이의 점점 살과 털이 찌고있어요 ㅎㅎ 겨울이는 잘 먹고 잘 지낸답니다. ', 13, 2, now(), now());
+--INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (3, '짱구는 모래 운동장에서 노는 걸 요즘 즐겨서 흰 털이 노래질 때까지 놀고있대요^^~', 14, 2, now(), now());
+--INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (4, '로지는 이제 사람들 손을 무서워하지 않고 사람들과 함께 잘 노는 강아지가 되어가고 있답니다', 15, 2, now(), now());
+--INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (5, '가을이는 다 나아서 잘 지내고 있답니다 :)', 16, 3, now(), now());
 
 
 -- INSERT DOG_STATUS_IMAGE
-INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (1, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus1.png', 1, now(), now());
-INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (2, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus2.png', 2, now(), now());
-INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (3, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus3.png', 3, now(), now());
-INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (4, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus4.png', 4, now(), now());
-INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (5, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus5.png', 5, now(), now());
+--INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (1, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus1.png', 1, now(), now());
+--INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (2, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus2.png', 2, now(), now());
+--INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (3, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus3.png', 3, now(), now());
+--INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (4, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus4.png', 4, now(), now());
+--INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (5, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus5.png', 5, now(), now());
 
 
 -- UPDATE DOG_STATUS_IMAGE
@@ -225,6 +225,7 @@ INSERT INTO bookmark(id, post_id, volunteer_id, created_date, modified_date) VAL
 -- v2
 -- INSERT INTERMEDIARY
 INSERT INTO intermediary (id, email, password, name, url, profile_image, intro, contact, role, is_option_agr, notification, guide, real_name, phone, created_date, modified_date) VALUES (7, 'i7@naver.com', '{bcrypt}$2a$10$wkmYUG/qvZFThCzq19yHredRc6u8nAhlAopbDE9p7n6JF6NgtLs8y', '감귤시보호소', 'https://connectdog7.site', 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/intermediary/intermediary6.png','감귤시가 운영중인 유기견 보호소입니다', '인스타그램 @gamgull_helper', 'AUTH_INTERMEDIARY', false, true, '감귤시에서 운영하는 감귤시보호소 공식계정입니다. 직원들이 상주하는 평일 9:00~19:0에만 응답이 가능합니다. ', '강승구', '01011112222', now(), now());
+INSERT INTO intermediary (id, email, password, name, url, profile_image, intro, contact, role, is_option_agr, notification, guide, real_name, phone, created_date, modified_date) VALUES (8, 'deletedIntermediary@connectdog.com', '{bcrypt}$2a$10$wkmYUG/qvZFThCzq19yHredRc6u8nAhlAopbDE9p7n6JF6NgtLs8y', '탈퇴한 사용자', null, null, null, null, 'AUTH_INTERMEDIARY', false, true, '탈퇴한 사용자입니다.', '탈퇴한 사용자', '01000000000', now(), now());
 
 
 -- INSERT DOG (post status 0 - 모집중)
@@ -482,25 +483,25 @@ UPDATE review SET main_image_id = 13 WHERE id = 13;
 
 
 -- INSERT DOG_STATUS
-INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (6, '몽이는 새로운 집에서 잘 놀구 있어요!! 너무 귀엽지 않나요..?', 37, 4, now(), now());
-INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (7, '요즘 1일 1산책 한대요!', 38, 4, now(), now());
-INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (8, '율무는 새로운 집에서 친구와 잘 지내고 있대요.', 39, 5, now(), now());
-INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (9, '찹쌀이는 이동 후에도 잘 지내고 있대요.', 40, 5, now(), now());
-INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (10, '수수의 건강이 많이 좋아져서 다시 건강하게 산책하며 돌아다니고 있어요.', 41, 6, now(), now());
-INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (11, '루시는 새 가족을 만나고 겁이 많이 없어졌대요. 이제는 먼저 사람을 보면 다가가서 부빈답니다', 42, 6, now(), now());
-INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (12, '감자는 병원 다녀와서 몸이 많이 좋아졌어요', 43, 7, now(), now());
-INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (13, '베키가 새로운 가족과 잘 지내고있대요!', 44, 7, now(), now());
+--INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (6, '몽이는 새로운 집에서 잘 놀구 있어요!! 너무 귀엽지 않나요..?', 37, 4, now(), now());
+--INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (7, '요즘 1일 1산책 한대요!', 38, 4, now(), now());
+--INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (8, '율무는 새로운 집에서 친구와 잘 지내고 있대요.', 39, 5, now(), now());
+--INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (9, '찹쌀이는 이동 후에도 잘 지내고 있대요.', 40, 5, now(), now());
+--INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (10, '수수의 건강이 많이 좋아져서 다시 건강하게 산책하며 돌아다니고 있어요.', 41, 6, now(), now());
+--INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (11, '루시는 새 가족을 만나고 겁이 많이 없어졌대요. 이제는 먼저 사람을 보면 다가가서 부빈답니다', 42, 6, now(), now());
+--INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (12, '감자는 병원 다녀와서 몸이 많이 좋아졌어요', 43, 7, now(), now());
+--INSERT INTO dog_status (id, content, post_id, intermediary_id, created_date, modified_date) VALUES (13, '베키가 새로운 가족과 잘 지내고있대요!', 44, 7, now(), now());
 
 
 -- INSERT DOG_STATUS_IMAGE
-INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (6, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus6.png', 6, now(), now());
-INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (7, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus7.png', 7, now(), now());
-INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (8, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus8.png', 8, now(), now());
-INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (9, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus9.png', 9, now(), now());
-INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (10, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus10.png', 10, now(), now());
-INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (11, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus11.png', 11, now(), now());
-INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (12, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus12.png', 12, now(), now());
-INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (13, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus13.png', 13, now(), now());
+--INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (6, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus6.png', 6, now(), now());
+--INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (7, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus7.png', 7, now(), now());
+--INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (8, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus8.png', 8, now(), now());
+--INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (9, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus9.png', 9, now(), now());
+--INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (10, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus10.png', 10, now(), now());
+--INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (11, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus11.png', 11, now(), now());
+--INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (12, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus12.png', 12, now(), now());
+--INSERT INTO dog_status_image (id, image, dog_status_id, created_date, modified_date) VALUES (13, 'https://connectdog-image.s3.ap-northeast-2.amazonaws.com/dogStatus/dogStatus13.png', 13, now(), now());
 
 
 -- UPDATE DOG_STATUS_IMAGE


### PR DESCRIPTION
## 💡 연관된 이슈
close #223 

## 📝 작업 내용
- 모집자 회원 탈퇴 API 구현

## 💬 리뷰 요구 사항
봉사자와 마찬가지로 탈퇴한 계정 표시를 위한 모집자 계정을 하나 추가했습니다. 
이때 구분을 위해 deletedVolunteer/Intermediary를 추가해 계정 정보를 넣어주었습니다.

Intermediary 엔티티와 연관관계에 있는 엔티티들은 다음과 같습니다.

1. Post
2. Application
3. IntermediaryFcm
4. IntermediaryNotification
5. DogStatus

1,2 번은 데이터를 삭제하지 않고 '탈퇴한 사용자'임을 표시해 주기로 하였고 3,4번은 삭제가 필요합니다. 

근황 엔티티는 현재 사용하지 않음에도 import.sql 실행되어 근황 데이터가 들어가서 삭제를 해주어야 탈퇴가 가능했습니다. 따라서 근황 관련 데이터 insert문을 주석처리했습니다!

추가로, Volunteer 탈퇴 시 VolunteerFcm, VolunteerNotification까지 벌크 연산으로 삭제 처리했습니다.

- 탈퇴한 모집자의 프로필을 보게 될 때의 처리를 어떻게 할 것인지 정해야 해요. 리뷰, 공고, 신청 응답 API에서 intermediaryId 필드를 보고 탈퇴한 사용자의 id인 경우 `1) 모집자 프로필 보기 버튼을 없애거나` `2) 버튼은 그대로 두고, 눌렀을 경우 탈퇴한 모집자임을 명시`해 주면 될 것 같습니다. 이건 프론트에게 선택권을 주도록 해볼게요!

추후 테스트 계정 여러 개 두고 탈퇴 후 여러 테스트 케이스로 후기, 공고, 신청 등의 데이터를 확인해 보면 좋을 것 같습니다!