### PR TITLE
[Feature] 봉사자, 모집자 이메일 중복 가능하도록 변경

### DIFF
--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
@@ -62,17 +62,31 @@ public class SignUpController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "이메일 인증번호 전송", description = "입력한 이메일로 인증번호를 전송합니다.",
+    @Operation(summary = "봉사자 - 이메일 인증번호 전송", description = "입력한 이메일로 인증번호를 전송합니다.",
             responses = {@ApiResponse(responseCode = "200", description = "이메일 인증번호 전송 성공")
                     , @ApiResponse(responseCode = "400"
                     , description = "V1, 이메일 형식에 맞지 않습니다. \t\n V1, 이메일은 필수 입력 값입니다. \t\n A1, 이미 존재하는 이메일입니다. \t\n A4, 이메일 인증 코드 전송을 실패했습니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
-    @PostMapping(value = {"/volunteers/sign-up/email", "/intermediaries/sign-up/email"})
-    public ResponseEntity<EmailResponse> mailConfirm(@RequestBody @Valid EmailRequest request){
-        EmailResponse emailResponse = emailService.sendEmail(request);
+    @PostMapping("/volunteers/sign-up/email")
+    public ResponseEntity<EmailResponse> sendEmailToVolunteer(@RequestBody @Valid EmailRequest request){
+        EmailResponse emailResponse = emailService.sendEmailToVolunteer(request);
         return ResponseEntity.ok(emailResponse);
     }
+
+    @Operation(summary = "모집자 - 이메일 인증번호 전송", description = "입력한 이메일로 인증번호를 전송합니다.",
+            responses = {@ApiResponse(responseCode = "200", description = "이메일 인증번호 전송 성공")
+                    , @ApiResponse(responseCode = "400"
+                    , description = "V1, 이메일 형식에 맞지 않습니다. \t\n V1, 이메일은 필수 입력 값입니다. \t\n A1, 이미 존재하는 이메일입니다. \t\n A4, 이메일 인증 코드 전송을 실패했습니다."
+                    , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+            })
+    @PostMapping("/intermediaries/sign-up/email")
+    public ResponseEntity<EmailResponse> sendEmailToIntermediary(@RequestBody @Valid EmailRequest request){
+        EmailResponse emailResponse = emailService.sendEmailToIntermediary(request);
+        return ResponseEntity.ok(emailResponse);
+    }
+
+
 
     @Operation(summary = "이동봉사자 소셜 로그인 추가 회원가입", description = "소셜 로그인하는 이동봉사자 추가 회원가입을 합니다.",
             security = { @SecurityRequirement(name = "bearer-key") },

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/controller/SignUpController.java
@@ -51,7 +51,8 @@ public class SignUpController {
                     , description = "V1, 이름은 필수 입력 값입니다 \t\n V1, 휴대전화 번호는 필수 입력 값입니다. \t\n V1, 유효하지 않은 휴대전화 번호입니다. \t\n " +
                     "V1, 이메일 형식에 맞지 않습니다. \t\n V1, 이메일은 필수 입력 값입니다. \t\n V1 문의 받을 연락처는 100자 이하로 입력해 주세요. \t\n " +
                     "V1, 영문+숫자 10자 이상 또는 영문+숫자+특수기호 8자 이상을 입력해 주세요. \t\n V1, 모집자명은 필수 입력 값입니다. \t\n " +
-                    "V1, 한줄 소개는 50자 이하로 입력해 주세요. \t\n A1, 이미 등록된 이메일입니다. \t\n F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다."
+                    "V1, 한줄 소개는 50자 이하로 입력해 주세요. \t\n A1, 이미 등록된 이메일입니다. \t\n F1, 파일이 존재하지 않습니다. \t\n F2, 파일 업로드에 실패했습니다. \t\n " +
+                    "A9, 이미 등록된 모집자명입니다."
                     , content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     @PostMapping(value = "/intermediaries/sign-up", consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/service/AuthService.java
@@ -72,9 +72,6 @@ public class AuthService {
         if (volunteerRepository.existsByEmail(request.email())) {
             throw new BadRequestException(ALREADY_EXIST_EMAIL);
         }
-        if (intermediaryRepository.existsByEmail(request.email())) {
-            throw new BadRequestException(ALREADY_EXIST_EMAIL);
-        }
         if (volunteerRepository.existsByNickname(request.nickname())) {
             throw new BadRequestException(ALREADY_EXIST_NICKNAME);
         }
@@ -92,8 +89,8 @@ public class AuthService {
         if (intermediaryRepository.existsByEmail(request.email())) {
             throw new BadRequestException(ALREADY_EXIST_EMAIL);
         }
-        if (volunteerRepository.existsByEmail(request.email())) {
-            throw new BadRequestException(ALREADY_EXIST_EMAIL);
+        if (intermediaryRepository.existsByName(request.name())) {
+            throw new BadRequestException(ALREADY_EXIST_NAME);
         }
         String profileImage = fileService.uploadFile(profileFile, "intermediary/profileImage");
         if (profileImage == null) {

--- a/src/main/java/com/pawwithu/connectdog/domain/auth/service/EmailService.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/auth/service/EmailService.java
@@ -81,20 +81,33 @@ public class EmailService {
     /**
      * 메일 전송
      */
-    public EmailResponse sendEmail(EmailRequest request) throws BadRequestException {
+    public EmailResponse sendEmailToVolunteer(EmailRequest request) throws BadRequestException {
         // 이메일 중복 검사
         if (volunteerRepository.existsByEmail(request.email())) {
             throw new BadRequestException(ALREADY_EXIST_EMAIL);
         }
-        if (intermediaryRepository.existsByEmail(request.email())) {
-            throw new BadRequestException(ALREADY_EXIST_EMAIL);
-        }
-        try{
+        try {
             // 메일전송에 필요한 정보 설정
             MimeMessage emailForm = createEmailForm(request.email());
             emailSender.send(emailForm);
             return new EmailResponse(authNum);
-        }catch (UnsupportedEncodingException | MessagingException e){
+        } catch (UnsupportedEncodingException | MessagingException e){
+            throw new BadRequestException(EMAIL_SEND_ERROR);
+        }
+
+    }
+
+    public EmailResponse sendEmailToIntermediary(EmailRequest request) {
+        // 이메일 중복 검사
+        if (intermediaryRepository.existsByEmail(request.email())) {
+            throw new BadRequestException(ALREADY_EXIST_EMAIL);
+        }
+        try {
+            // 메일전송에 필요한 정보 설정
+            MimeMessage emailForm = createEmailForm(request.email());
+            emailSender.send(emailForm);
+            return new EmailResponse(authNum);
+        } catch (UnsupportedEncodingException | MessagingException e){
             throw new BadRequestException(EMAIL_SEND_ERROR);
         }
 

--- a/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
+++ b/src/main/java/com/pawwithu/connectdog/domain/volunteer/entity/Volunteer.java
@@ -61,6 +61,7 @@ public class Volunteer extends BaseTimeEntity {
         this.role = role;
         this.profileImageNum = profileImageNum;
         this.isOptionAgr = isOptionAgr;
+        this.notification = true;
     }
 
     public void updateNameAndPhone(String name, String phone) {

--- a/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
+++ b/src/main/java/com/pawwithu/connectdog/error/ErrorCode.java
@@ -15,6 +15,7 @@ public enum ErrorCode {
     NOT_ALLOWED_MEMBER("A6", "해당 요청에 대한 권한이 없습니다."),
     NOT_AUTHENTICATED_REQUEST("A7", "유효한 JWT 토큰이 없습니다."),
     ALREADY_EXIST_PHONE("A8", "이미 등록된 전화번호입니다."),
+    ALREADY_EXIST_NAME("A9", "이미 등록된 모집자명입니다."),
 
 
     VOLUNTEER_NOT_FOUND("M1", "해당 이동봉사자를 찾을 수 없습니다."), // Member -> M (이동봉사자, 이동봉사 중개 통일)

--- a/src/test/java/com/pawwithu/connectdog/domain/auth/controller/SignUpControllerTest.java
+++ b/src/test/java/com/pawwithu/connectdog/domain/auth/controller/SignUpControllerTest.java
@@ -50,13 +50,13 @@ class SignUpControllerTest {
                 .build();
     }
     @Test
-    void 이메일_인증번호_전송() throws Exception{
+    void 봉사자_이메일_인증번호_전송() throws Exception{
         //given
         EmailRequest request = new EmailRequest("email@naver.com");
         EmailResponse response = new EmailResponse("authCode123");
 
         //when
-        when(emailService.sendEmail(any())).thenReturn(response);
+        when(emailService.sendEmailToVolunteer(any())).thenReturn(response);
         ResultActions result = mockMvc.perform(
                 post("/volunteers/sign-up/email")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -64,7 +64,25 @@ class SignUpControllerTest {
         );
         //then
         result.andExpect(status().isOk());
-        verify(emailService, times(1)).sendEmail(any());
+        verify(emailService, times(1)).sendEmailToVolunteer(any());
+    }
+
+    @Test
+    void 모집자_이메일_인증번호_전송() throws Exception{
+        //given
+        EmailRequest request = new EmailRequest("email@naver.com");
+        EmailResponse response = new EmailResponse("authCode123");
+
+        //when
+        when(emailService.sendEmailToIntermediary(any())).thenReturn(response);
+        ResultActions result = mockMvc.perform(
+                post("/intermediaries/sign-up/email")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+        );
+        //then
+        result.andExpect(status().isOk());
+        verify(emailService, times(1)).sendEmailToIntermediary(any());
     }
 
 


### PR DESCRIPTION
## 💡 연관된 이슈
close #238 

## 📝 작업 내용
- 봉사자, 모집자 회원가입 시 이메일 중복 확인 로직 분리
- 봉사자 모집자 이메일 전송 api 분리
- 봉사자 모집자 이메일 전송 테스트 코드 수정

## 💬 리뷰 요구 사항